### PR TITLE
Workaround for Chrome 41 issue Canvas + Radeon :

### DIFF
--- a/src/js/rendering/frame/FrameRenderer.js
+++ b/src/js/rendering/frame/FrameRenderer.js
@@ -239,7 +239,7 @@
 
     if (this.canvas.width*this.zoom < this.displayCanvas.width || this.canvas.height*this.zoom < this.displayCanvas.height) {
       displayContext.fillStyle = Constants.ZOOMED_OUT_BACKGROUND_COLOR;
-      displayContext.fillRect(0,0,this.displayCanvas.width, this.displayCanvas.height);
+      displayContext.fillRect(0,0,this.displayCanvas.width - 1, this.displayCanvas.height - 1);
     }
 
     displayContext.translate(


### PR DESCRIPTION
Issue opened at https://code.google.com/p/chromium/issues/detail?id=469906
Workaround in FrameRenderer.js is to decrease the width+height of the
fillRect of 1 pixel.
Issue seems to impact only Radeon users (not sure if all cards are
impacted)