### PR TITLE
Adds the ability to export a scaled spritesheet.

### DIFF
--- a/src/css/settings-export.css
+++ b/src/css/settings-export.css
@@ -56,3 +56,24 @@
   background: rgba(0,0,0,0.5);
   color: white;
 }
+
+.scaling-factor-input {
+  margin: 5px;
+  vertical-align: middle;
+  width: 145px;
+}
+
+.scaling-factor-text {
+  height: 31px;
+  display: inline-block;
+  line-height: 30px;
+  width: 40px;
+  border: 1px solid grey;
+  box-sizing: border-box;
+  border-radius: 3px;
+  text-align: center;
+}
+
+.settings-section--export > .settings-item > label {
+  display: block;
+}

--- a/src/css/settings-export.css
+++ b/src/css/settings-export.css
@@ -57,6 +57,10 @@
   color: white;
 }
 
+.scaling-factor {
+  margin-bottom: 10px;
+}
+
 .scaling-factor-input {
   margin: 5px;
   vertical-align: middle;
@@ -72,8 +76,4 @@
   box-sizing: border-box;
   border-radius: 3px;
   text-align: center;
-}
-
-.settings-section--export > .settings-item > label {
-  display: block;
 }

--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -132,7 +132,6 @@
 
 .settings-description {
   margin : 0 0 10px 0;
-  display : inline-block;
 }
 
 .settings-form-section {

--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -84,7 +84,7 @@
 .drawer-content {
   overflow: hidden;
   background-color: #444;
-  height: 550px;
+  height: 600px;
   max-height: 100%;
   width: 280px;
   border-top-left-radius: 4px;

--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -84,7 +84,7 @@
 .drawer-content {
   overflow: hidden;
   background-color: #444;
-  height: 600px;
+  height: 550px;
   max-height: 100%;
   width: 280px;
   border-top-left-radius: 4px;

--- a/src/js/controller/settings/exportimage/ImageExportController.js
+++ b/src/js/controller/settings/exportimage/ImageExportController.js
@@ -14,6 +14,7 @@
     var scalingFactorInput = document.querySelector('.scaling-factor-input');
     scalingFactorInput.value = pskl.UserSettings.get(pskl.UserSettings.EXPORT_SCALING);
     this.addEventListener(scalingFactorInput, 'change', this.onScalingFactorChange_);
+    this.addEventListener(scalingFactorInput, 'input', this.onScalingFactorChange_);
     this.updateScalingFactorText_(scalingFactorInput.value);
 
     this.pngExportController.init();

--- a/src/js/controller/settings/exportimage/ImageExportController.js
+++ b/src/js/controller/settings/exportimage/ImageExportController.js
@@ -24,6 +24,7 @@
   ns.ImageExportController.prototype.destroy = function () {
     this.pngExportController.destroy();
     this.gifExportController.destroy();
+    this.superclass.destroy.call(this);
   };
 
   ns.ImageExportController.prototype.onScalingFactorChange_ = function (evt) {

--- a/src/js/controller/settings/exportimage/ImageExportController.js
+++ b/src/js/controller/settings/exportimage/ImageExportController.js
@@ -7,7 +7,15 @@
     this.gifExportController = new ns.GifExportController(piskelController);
   };
 
+  pskl.utils.inherit(ns.ImageExportController, pskl.controller.settings.AbstractSettingController);
+
   ns.ImageExportController.prototype.init = function () {
+    // Output Scaling Factor
+    var scalingFactorInput = document.querySelector('.scaling-factor-input');
+    scalingFactorInput.value = pskl.UserSettings.get(pskl.UserSettings.EXPORT_SCALING);
+    this.addEventListener(scalingFactorInput, 'change', this.onScalingFactorChange_);
+    this.updateScalingFactorText_(scalingFactorInput.value);
+
     this.pngExportController.init();
     this.gifExportController.init();
   };
@@ -15,5 +23,21 @@
   ns.ImageExportController.prototype.destroy = function () {
     this.pngExportController.destroy();
     this.gifExportController.destroy();
+  };
+
+  ns.ImageExportController.prototype.onScalingFactorChange_ = function (evt) {
+    var target = evt.target;
+    var value = Math.round(parseFloat(target.value));
+    if (!isNaN(value)) {
+      this.updateScalingFactorText_(value);
+      pskl.UserSettings.set(pskl.UserSettings.EXPORT_SCALING, value);
+    } else {
+      target.value = pskl.UserSettings.get(pskl.UserSettings.EXPORT_SCALING);
+    }
+  };
+
+  ns.ImageExportController.prototype.updateScalingFactorText_ = function (scale) {
+    var scalingFactorText = document.querySelector('.scaling-factor-text');
+    scalingFactorText.innerHTML = scale + 'x';
   };
 })();

--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -24,7 +24,17 @@
 
   ns.PngExportController.prototype.onPngDownloadButtonClick_ = function (evt) {
     var fileName = this.getPiskelName_() + '.png';
-    pskl.utils.BlobUtils.canvasToBlob(this.getFramesheetAsCanvas(), function(blob) {
+
+    var outputCanvas = this.getFramesheetAsCanvas();
+
+    var scalingFactor = pskl.UserSettings.get(pskl.UserSettings.EXPORT_SCALING);
+    if (scalingFactor > 1) {
+      var width = outputCanvas.width * scalingFactor;
+      var height = outputCanvas.height * scalingFactor;
+      outputCanvas = pskl.utils.ImageResizer.resize(outputCanvas, width, height, false);
+    }
+
+    pskl.utils.BlobUtils.canvasToBlob(outputCanvas, function(blob) {
       pskl.utils.FileUtils.downloadAsFile(blob, fileName);
     });
   };

--- a/src/js/utils/BlobUtils.js
+++ b/src/js/utils/BlobUtils.js
@@ -23,27 +23,8 @@
       callback(blob);
     },
 
-    canvasToBlob : function (sourceCanvas, callback, type /*, ...args*/) {
+    canvasToBlob : function (canvas, callback, type /*, ...args*/) {
       type = type || 'image/png';
-
-      var exportScaling = pskl.UserSettings.get(pskl.UserSettings.EXPORT_SCALING);
-      var canvas;
-      if (exportScaling > 1) {
-        // Scale the input canvas to an offscreen canvas.
-        canvas = document.createElement('canvas');
-        canvas.width = sourceCanvas.width * exportScaling;
-        canvas.height = sourceCanvas.height * exportScaling;
-
-        var ctx = canvas.getContext('2d');
-        ctx.mozImageSmoothingEnabled = false;
-        ctx.webkitImageSmoothingEnabled = false;
-        ctx.msImageSmoothingEnabled = false;
-        ctx.imageSmoothingEnabled = false;
-
-        ctx.drawImage(sourceCanvas, 0, 0, sourceCanvas.width, sourceCanvas.height, 0, 0, canvas.width, canvas.height);
-      } else {
-        canvas = sourceCanvas;
-      }
 
       if (canvas.mozGetAsFile) {
         callback(canvas.mozGetAsFile('canvas', type));

--- a/src/js/utils/BlobUtils.js
+++ b/src/js/utils/BlobUtils.js
@@ -23,8 +23,27 @@
       callback(blob);
     },
 
-    canvasToBlob : function (canvas, callback, type /*, ...args*/) {
+    canvasToBlob : function (sourceCanvas, callback, type /*, ...args*/) {
       type = type || 'image/png';
+
+      var exportScaling = pskl.UserSettings.get(pskl.UserSettings.EXPORT_SCALING);
+      var canvas;
+      if (exportScaling > 1) {
+        // Scale the input canvas to an offscreen canvas.
+        canvas = document.createElement('canvas');
+        canvas.width = sourceCanvas.width * exportScaling;
+        canvas.height = sourceCanvas.height * exportScaling;
+
+        var ctx = canvas.getContext('2d');
+        ctx.mozImageSmoothingEnabled = false;
+        ctx.webkitImageSmoothingEnabled = false;
+        ctx.msImageSmoothingEnabled = false;
+        ctx.imageSmoothingEnabled = false;
+
+        ctx.drawImage(sourceCanvas, 0, 0, sourceCanvas.width, sourceCanvas.height, 0, 0, canvas.width, canvas.height);
+      } else {
+        canvas = sourceCanvas;
+      }
 
       if (canvas.mozGetAsFile) {
         callback(canvas.mozGetAsFile('canvas', type));

--- a/src/js/utils/UserSettings.js
+++ b/src/js/utils/UserSettings.js
@@ -11,6 +11,7 @@
     ONION_SKIN : 'ONION_SKIN',
     LAYER_PREVIEW : 'LAYER_PREVIEW',
     LAYER_OPACITY : 'LAYER_OPACITY',
+    EXPORT_SCALING: 'EXPORT_SCALING',
 
     KEY_TO_DEFAULT_VALUE_MAP_ : {
       'GRID_WIDTH' : 0,
@@ -24,7 +25,8 @@
       'TILED_PREVIEW' : false,
       'ONION_SKIN' : false,
       'LAYER_OPACITY' : 0.2,
-      'LAYER_PREVIEW' : true
+      'LAYER_PREVIEW' : true,
+      'EXPORT_SCALING' : 1
     },
 
     /**

--- a/src/templates/settings/export.html
+++ b/src/templates/settings/export.html
@@ -1,4 +1,14 @@
 <div class="settings-section">
+
+  <div class="settings-title settings-section--export">
+    General Export Settings
+  </div>
+  <div class="settings-item">
+    <span class="settings-description" style="display:block"><label for="scaling-factor">Output Scaling Factor</label></span>
+    <span class="settings-description" style="display:block">Currently affects only spritesheet export.</span>
+    <input type="range" class="scaling-factor-input" name="scaling-factor" min="1"  max="32" step="1"/>
+    <span class="scaling-factor-text"></span>
+  </div>
   <div class="settings-title">
     Export Spritesheet
   </div>

--- a/src/templates/settings/export.html
+++ b/src/templates/settings/export.html
@@ -1,27 +1,22 @@
 <div class="settings-section">
-
-  <div class="settings-title settings-section--export">
-    General Export Settings
-  </div>
-  <div class="settings-item">
-    <span class="settings-description" style="display:block"><label for="scaling-factor">Output Scaling Factor</label></span>
-    <span class="settings-description" style="display:block">Currently affects only spritesheet export.</span>
-    <input type="range" class="scaling-factor-input" name="scaling-factor" min="1"  max="32" step="1"/>
-    <span class="scaling-factor-text"></span>
-  </div>
   <div class="settings-title">
     Export Spritesheet
   </div>
   <div class="settings-item">
-    <span class="settings-description">PNG with all frames side by side.</span>
+    <div class="settings-description">PNG with all frames side by side.</div>
+    <div class="settings-description"><label for="scaling-factor">Output Scaling Factor</label></div>
+    <div class="scaling-factor">
+      <input type="range" class="scaling-factor-input" name="scaling-factor" min="1"  max="32" step="1"/>
+      <span class="scaling-factor-text"></span>
+    </div>
     <button type="button" class="button button-primary png-download-button">Download PNG</button>
   </div>
   <div class="settings-title">
     Export as ZIP
   </div>
   <div class="settings-item">
-    <span class="settings-description">ZIP with one PNG file per frame.</span>
-    <span class="settings-description" style="display:block">File names will start with the prefix below.</span>
+    <div class="settings-description">ZIP with one PNG file per frame.</div>
+    <div class="settings-description">File names will start with the prefix below.</div>
     <div class="settings-item">
       <label>Prefix</label>
       <input class="zip-prefix-name  textfield" type="text" placeholder="PNG file prefix ...">

--- a/src/templates/settings/export.html
+++ b/src/templates/settings/export.html
@@ -4,8 +4,11 @@
   </div>
   <div class="settings-item">
     <div class="settings-description">PNG with all frames side by side.</div>
-    <div class="settings-description"><label for="scaling-factor">Output Scaling Factor</label></div>
-    <div class="scaling-factor">
+    <div class="scaling-factor"
+      title="Scale the exported PNG spritesheet"
+      rel="tooltip"
+      data-placement="top">
+      <div class="settings-description"><label for="scaling-factor">Output Scaling Factor</label></div>
       <input type="range" class="scaling-factor-input" name="scaling-factor" min="1"  max="32" step="1"/>
       <span class="scaling-factor-text"></span>
     </div>


### PR DESCRIPTION
This is a patch for the second feature I requested in this tweet: https://twitter.com/lopar/status/637802318008717312

Please let me know if there are any tweaks to the UX or whatnot. For one, I was debating whether the scale should appear as a general export setting or as part of the spritesheet setting section, since it currently only works for spritesheets. I went with general export since it'd be nice to extend it to others types such as ZIP in the future, but I'll defer to whatever you think is best there.

The scaling method with canvasses should work on all modern browsers (IE 11+ and Edge, Chrome, Firefox, Safari, Opera probably).