### PR TITLE
Integrate selected colors service

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "piskel",
   "main": "./dest/index.html",
   "description": "Web based 2d animations editor",
-  "version": "0.5.2",
+  "version": "0.5.5-SNAPSHOT",
   "homepage": "http://github.com/juliandescottes/piskel",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "karma-chrome-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.1.4",
+    "jasmine-core": "^2.1.0",
     "load-grunt-tasks": "^3.1.0"
   },
   "window": {

--- a/src/css/dialogs.css
+++ b/src/css/dialogs.css
@@ -21,7 +21,7 @@
 }
 
 #dialog-container-wrapper.animated {
-  transition: opacity 0.5s;
+  transition: opacity 0.2s;
 }
 
 #dialog-container-wrapper.show {
@@ -45,7 +45,7 @@
 }
 
 .animated #dialog-container {
-  transition:margin-top 0.5s;
+  transition:margin-top 0.2s;
 }
 
 .show #dialog-container {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -47,9 +47,7 @@
       this.currentColorsService = new pskl.service.CurrentColorsService(this.piskelController);
       this.currentColorsService.init();
 
-      this.palettesListController = new pskl.controller.PalettesListController(
-        this.paletteController,
-        this.currentColorsService);
+      this.palettesListController = new pskl.controller.PalettesListController(this.currentColorsService);
       this.palettesListController.init();
 
       this.cursorCoordinatesController = new pskl.controller.CursorCoordinatesController(this.piskelController);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -41,6 +41,9 @@
       this.selectedColorsService = new pskl.service.SelectedColorsService();
       this.selectedColorsService.init();
 
+      this.mouseStateService = new pskl.service.MouseStateService();
+      this.mouseStateService.init();
+
       this.paletteController = new pskl.controller.PaletteController();
       this.paletteController.init();
 

--- a/src/js/controller/DrawingController.js
+++ b/src/js/controller/DrawingController.js
@@ -256,7 +256,6 @@
     var frame = this.piskelController.getCurrentFrame();
     var coords = this.getSpriteCoordinates(event.clientX, event.clientY);
     if (this.isClicked) {
-      $.publish(Events.MOUSE_EVENT, [event, this]);
       // A mouse button was clicked on the drawing canvas before this mouseup event,
       // the user was probably drawing on the canvas.
       // Note: The mousemove movement (and the mouseup) may end up outside
@@ -282,6 +281,7 @@
 
         $.publish(Events.TOOL_RELEASED);
       }
+      $.publish(Events.MOUSE_EVENT, [event, this]);
     }
   };
 

--- a/src/js/controller/DrawingController.js
+++ b/src/js/controller/DrawingController.js
@@ -151,7 +151,6 @@
       this.currentToolBehavior.applyToolAt(
         coords.x,
         coords.y,
-        this.getCurrentColor_(),
         frame,
         this.overlayFrame,
         event
@@ -194,7 +193,6 @@
         this.currentToolBehavior.moveToolAt(
           coords.x | 0,
           coords.y | 0,
-          this.getCurrentColor_(),
           currentFrame,
           this.overlayFrame,
           event
@@ -204,7 +202,6 @@
       this.currentToolBehavior.moveUnactiveToolAt(
         coords.x,
         coords.y,
-        this.getCurrentColor_(),
         currentFrame,
         this.overlayFrame,
         event
@@ -273,7 +270,6 @@
         this.currentToolBehavior.releaseToolAt(
           coords.x,
           coords.y,
-          this.getCurrentColor_(),
           this.piskelController.getCurrentFrame(),
           this.overlayFrame,
           event
@@ -297,25 +293,6 @@
 
   ns.DrawingController.prototype.getScreenCoordinates = function(spriteX, spriteY) {
     return this.renderer.reverseCoordinates(spriteX, spriteY);
-  };
-
-  /**
-   * @private
-   */
-  ns.DrawingController.prototype.getCurrentColor_ = function () {
-    // WARNING : Do not rely on the current event to get the current color!
-    // It might seem like a good idea, and works perfectly fine on Chrome
-    // Sadly Firefox and IE found clever, for some reason, to set event.button to 0
-    // on a mouse move event
-    // This always matches a LEFT mouse button which is __really__ not helpful
-
-    if (pskl.app.mouseStateService.isRightButtonPressed()) {
-      return pskl.app.selectedColorsService.getSecondaryColor();
-    } else if (pskl.app.mouseStateService.isLeftButtonPressed()) {
-      return pskl.app.selectedColorsService.getPrimaryColor();
-    } else {
-      return Constants.DEFAULT_PEN_COLOR;
-    }
   };
 
   /**

--- a/src/js/controller/DrawingController.js
+++ b/src/js/controller/DrawingController.js
@@ -47,9 +47,6 @@
     this.isClicked = false;
     this.previousMousemoveTime = 0;
     this.currentToolBehavior = null;
-
-    // State of clicked button (need to be stateful here, see comment in getCurrentColor_)
-    this.currentMouseButton_ = Constants.LEFT_BUTTON;
   };
 
   ns.DrawingController.prototype.init = function () {
@@ -145,7 +142,6 @@
     var coords = this.getSpriteCoordinates(event.clientX, event.clientY);
 
     this.isClicked = true;
-    this.setCurrentButton(event);
 
     if (event.button === Constants.MIDDLE_BUTTON) {
       this.dragHandler.startDrag(event.clientX, event.clientY);
@@ -191,12 +187,10 @@
     var currentFrame = this.piskelController.getCurrentFrame();
 
     if (this.isClicked) {
-      if (this.currentMouseButton_ == Constants.MIDDLE_BUTTON) {
+      if (pskl.app.mouseStateService.isMiddleButtonPressed()) {
         this.dragHandler.updateDrag(x, y);
       } else {
         $.publish(Events.MOUSE_EVENT, [event, this]);
-        // Warning : do not call setCurrentButton here
-        // mousemove do not have the correct mouse button information on all browsers
         this.currentToolBehavior.moveToolAt(
           coords.x | 0,
           coords.y | 0,
@@ -269,9 +263,8 @@
       // of the drawing canvas.
 
       this.isClicked = false;
-      this.setCurrentButton(event);
 
-      if (event.button === Constants.MIDDLE_BUTTON) {
+      if (pskl.app.mouseStateService.isMiddleButtonPressed()) {
         if (this.dragHandler.isDragging()) {
           this.dragHandler.stopDrag();
         } else if (frame.containsPixel(coords.x, coords.y)) {
@@ -306,10 +299,6 @@
     return this.renderer.reverseCoordinates(spriteX, spriteY);
   };
 
-  ns.DrawingController.prototype.setCurrentButton = function (event) {
-    this.currentMouseButton_ = event.button;
-  };
-
   /**
    * @private
    */
@@ -320,9 +309,9 @@
     // on a mouse move event
     // This always matches a LEFT mouse button which is __really__ not helpful
 
-    if (this.currentMouseButton_ == Constants.RIGHT_BUTTON) {
+    if (pskl.app.mouseStateService.isRightButtonPressed()) {
       return pskl.app.selectedColorsService.getSecondaryColor();
-    } else if (this.currentMouseButton_ == Constants.LEFT_BUTTON) {
+    } else if (pskl.app.mouseStateService.isLeftButtonPressed()) {
       return pskl.app.selectedColorsService.getPrimaryColor();
     } else {
       return Constants.DEFAULT_PEN_COLOR;

--- a/src/js/controller/DrawingController.js
+++ b/src/js/controller/DrawingController.js
@@ -321,9 +321,9 @@
     // This always matches a LEFT mouse button which is __really__ not helpful
 
     if (this.currentMouseButton_ == Constants.RIGHT_BUTTON) {
-      return this.paletteController.getSecondaryColor();
+      return pskl.app.selectedColorsService.getSecondaryColor();
     } else if (this.currentMouseButton_ == Constants.LEFT_BUTTON) {
-      return this.paletteController.getPrimaryColor();
+      return pskl.app.selectedColorsService.getPrimaryColor();
     } else {
       return Constants.DEFAULT_PEN_COLOR;
     }

--- a/src/js/controller/PaletteController.js
+++ b/src/js/controller/PaletteController.js
@@ -1,11 +1,7 @@
 (function () {
   var ns = $.namespace('pskl.controller');
 
-  ns.PaletteController = function () {
-    // TODO(grosbouddha): Reuse default colors from SelectedColorsService.
-    this.primaryColor =  Constants.DEFAULT_PEN_COLOR;
-    this.secondaryColor =  Constants.TRANSPARENT_COLOR;
-  };
+  ns.PaletteController = function () {};
 
   /**
    * @public
@@ -52,9 +48,9 @@
   ns.PaletteController.prototype.onPickerChange_ = function(evt, isPrimary) {
     var inputPicker = $(evt.target);
     if (evt.data.isPrimary) {
-      this.setPrimaryColor(inputPicker.val());
+      this.setPrimaryColor_(inputPicker.val());
     } else {
-      this.setSecondaryColor(inputPicker.val());
+      this.setSecondaryColor_(inputPicker.val());
     }
   };
 
@@ -64,41 +60,30 @@
   ns.PaletteController.prototype.onColorSelected_ = function(args, evt, color) {
     var inputPicker = $(evt.target);
     if (args.isPrimary) {
-      this.setPrimaryColor(color);
+      this.setPrimaryColor_(color);
     } else {
-      this.setSecondaryColor(color);
+      this.setSecondaryColor_(color);
     }
   };
 
-  ns.PaletteController.prototype.setPrimaryColor = function (color) {
-    this.primaryColor = color;
+  ns.PaletteController.prototype.setPrimaryColor_ = function (color) {
     this.updateColorPicker_(color, $('#color-picker'));
     $.publish(Events.PRIMARY_COLOR_SELECTED, [color]);
   };
 
-  ns.PaletteController.prototype.setSecondaryColor = function (color) {
-    this.secondaryColor = color;
+  ns.PaletteController.prototype.setSecondaryColor_ = function (color) {
     this.updateColorPicker_(color, $('#secondary-color-picker'));
     $.publish(Events.SECONDARY_COLOR_SELECTED, [color]);
   };
 
-  ns.PaletteController.prototype.getPrimaryColor = function () {
-    return this.primaryColor;
-  };
-
-  ns.PaletteController.prototype.getSecondaryColor = function () {
-    return this.secondaryColor;
-  };
-
   ns.PaletteController.prototype.swapColors = function () {
-    var primaryColor = this.getPrimaryColor();
-    this.setPrimaryColor(this.getSecondaryColor());
-    this.setSecondaryColor(primaryColor);
+    var primaryColor = pskl.app.selectedColorsService.getPrimaryColor();
+    this.setPrimaryColor_(pskl.app.selectedColorsService.getSecondaryColor());
+    this.setSecondaryColor_(primaryColor);
   };
 
   ns.PaletteController.prototype.resetColors = function () {
-    this.setPrimaryColor(Constants.DEFAULT_PEN_COLOR);
-    this.setSecondaryColor(Constants.TRANSPARENT_COLOR);
+    pskl.app.selectedColorsService.reset();
   };
 
   /**

--- a/src/js/controller/PalettesListController.js
+++ b/src/js/controller/PalettesListController.js
@@ -10,10 +10,9 @@
   // I apologize to my future self for this one.
   var NO_SCROLL_MAX_COLORS = 20;
 
-  ns.PalettesListController = function (paletteController, usedColorService) {
+  ns.PalettesListController = function (usedColorService) {
     this.usedColorService = usedColorService;
     this.paletteService = pskl.app.paletteService;
-    this.paletteController = paletteController;
   };
 
   ns.PalettesListController.prototype.init = function () {
@@ -184,13 +183,13 @@
     this.removeClass_(PRIMARY_COLOR_CLASSNAME);
     this.removeClass_(SECONDARY_COLOR_CLASSNAME);
 
-    var colorContainer = this.getColorContainer_(this.paletteController.getSecondaryColor());
+    var colorContainer = this.getColorContainer_(pskl.app.selectedColorsService.getSecondaryColor());
     if (colorContainer) {
       colorContainer.classList.remove(PRIMARY_COLOR_CLASSNAME);
       colorContainer.classList.add(SECONDARY_COLOR_CLASSNAME);
     }
 
-    colorContainer = this.getColorContainer_(this.paletteController.getPrimaryColor());
+    colorContainer = this.getColorContainer_(pskl.app.selectedColorsService.getPrimaryColor());
     if (colorContainer) {
       colorContainer.classList.remove(SECONDARY_COLOR_CLASSNAME);
       colorContainer.classList.add(PRIMARY_COLOR_CLASSNAME);

--- a/src/js/devtools/DrawingTestRecorder.js
+++ b/src/js/devtools/DrawingTestRecorder.js
@@ -45,8 +45,8 @@
         width : this.piskelController.getWidth(),
         height : this.piskelController.getHeight()
       },
-      primaryColor : pskl.app.paletteController.getPrimaryColor(),
-      secondaryColor : pskl.app.paletteController.getSecondaryColor(),
+      primaryColor : pskl.app.selectedColorsService.getPrimaryColor(),
+      secondaryColor : pskl.app.selectedColorsService.getSecondaryColor(),
       selectedTool : pskl.app.toolController.currentSelectedTool.instance.toolId
     };
   };

--- a/src/js/rendering/frame/FrameRenderer.js
+++ b/src/js/rendering/frame/FrameRenderer.js
@@ -140,11 +140,23 @@
   };
 
   ns.FrameRenderer.prototype.getGridWidth = function () {
-    if (this.supportGridRendering) {
-      return this.gridWidth_;
-    } else {
+    if (!this.supportGridRendering) {
       return 0;
     }
+
+    return this.gridWidth_;
+  };
+
+  /**
+   * Compute a grid width value best suited to the current display context,
+   * particularly for the current zoom level
+   */
+  ns.FrameRenderer.prototype.computeGridWidthForDisplay_ = function () {
+    var gridWidth = this.getGridWidth();
+    while (this.zoom < 6 * gridWidth) {
+      gridWidth--;
+    }
+    return gridWidth;
   };
 
   ns.FrameRenderer.prototype.updateMargins_ = function (frame) {
@@ -249,7 +261,7 @@
 
     var isIE10 = pskl.utils.UserAgent.isIE && pskl.utils.UserAgent.version === 10;
 
-    var gridWidth = this.getGridWidth();
+    var gridWidth = this.computeGridWidthForDisplay_();
     var isGridEnabled = gridWidth > 0;
     if (isGridEnabled || isIE10) {
       var scaled = pskl.utils.ImageResizer.resizeNearestNeighbour(this.canvas, this.zoom, gridWidth);

--- a/src/js/service/MouseStateService.js
+++ b/src/js/service/MouseStateService.js
@@ -1,0 +1,39 @@
+(function () {
+  var ns = $.namespace('pskl.service');
+
+  var BUTTON_UNSET = null;
+
+  ns.MouseStateService = function () {
+    this.lastButtonPressed_ = BUTTON_UNSET;
+  };
+
+  ns.MouseStateService.prototype.init = function () {
+    $.subscribe(Events.MOUSE_EVENT, this.onMouseEvent_.bind(this));
+  };
+
+  ns.MouseStateService.prototype.isLeftButtonPressed = function () {
+    return this.isMouseButtonPressed_(Constants.LEFT_BUTTON);
+  };
+
+  ns.MouseStateService.prototype.isRightButtonPressed = function () {
+    return this.isMouseButtonPressed_(Constants.RIGHT_BUTTON);
+  };
+
+  ns.MouseStateService.prototype.isMiddleButtonPressed = function () {
+    return this.isMouseButtonPressed_(Constants.MIDDLE_BUTTON);
+  };
+
+  ns.MouseStateService.prototype.isMouseButtonPressed_ = function (mouseButton) {
+    return this.lastButtonPressed_ != BUTTON_UNSET && this.lastButtonPressed_ == mouseButton;
+  }
+
+  ns.MouseStateService.prototype.onMouseEvent_ = function(evt, mouseEvent) {
+    if (mouseEvent.type == 'mousedown') {
+      this.lastButtonPressed_ = mouseEvent.button;
+    } else if (mouseEvent.type == 'mouseup') {
+      this.lastButtonPressed_ = BUTTON_UNSET;
+    }
+    // Warning : do not call setCurrentButton here
+        // mousemove do not have the correct mouse button information on all browsers
+  };
+})();

--- a/src/js/service/MouseStateService.js
+++ b/src/js/service/MouseStateService.js
@@ -3,6 +3,12 @@
 
   var BUTTON_UNSET = null;
 
+  /**
+   * This service exists mostly due to a FF/IE bug.
+   * For mousemove events, the button type is set to 0 (e.g. left button type) whatever was the
+   * pressed button on mousedown. We use this service to cache the button type value on mousedown
+   * and make it available to mousemove events.
+   */
   ns.MouseStateService = function () {
     this.lastButtonPressed_ = BUTTON_UNSET;
   };
@@ -25,7 +31,7 @@
 
   ns.MouseStateService.prototype.isMouseButtonPressed_ = function (mouseButton) {
     return this.lastButtonPressed_ != BUTTON_UNSET && this.lastButtonPressed_ == mouseButton;
-  }
+  };
 
   ns.MouseStateService.prototype.onMouseEvent_ = function(evt, mouseEvent) {
     if (mouseEvent.type == 'mousedown') {
@@ -33,7 +39,5 @@
     } else if (mouseEvent.type == 'mouseup') {
       this.lastButtonPressed_ = BUTTON_UNSET;
     }
-    // Warning : do not call setCurrentButton here
-        // mousemove do not have the correct mouse button information on all browsers
   };
 })();

--- a/src/js/service/SelectedColorsService.js
+++ b/src/js/service/SelectedColorsService.js
@@ -2,8 +2,7 @@
   var ns = $.namespace('pskl.service');
 
   ns.SelectedColorsService = function () {
-    this.primaryColor_ = Constants.DEFAULT_PEN_COLOR;
-    this.secondaryColor_ = Constants.TRANSPARENT_COLOR;
+    this.reset();
   };
 
   ns.SelectedColorsService.prototype.init = function () {
@@ -11,11 +10,17 @@
     $.subscribe(Events.SECONDARY_COLOR_SELECTED, this.onSecondaryColorUpdate_.bind(this));
   };
 
-  ns.SelectedColorsService.prototype.getColors = function () {
-    if (this.primaryColor_ === null || this.secondaryColor_ === null) {
-      throw 'SelectedColorsService not properly initialized.';
-    }
-    return [this.primaryColor_, this.secondaryColor_];
+  ns.SelectedColorsService.prototype.getPrimaryColor = function () {
+    return this.primaryColor_;
+  };
+
+  ns.SelectedColorsService.prototype.getSecondaryColor = function () {
+    return this.secondaryColor_;
+  };
+
+  ns.SelectedColorsService.prototype.reset = function () {
+    this.primaryColor_ = Constants.DEFAULT_PEN_COLOR;
+    this.secondaryColor_ = Constants.TRANSPARENT_COLOR;
   };
 
   ns.SelectedColorsService.prototype.onPrimaryColorUpdate_ = function (evt, color) {

--- a/src/js/tools/drawing/BaseTool.js
+++ b/src/js/tools/drawing/BaseTool.js
@@ -13,9 +13,9 @@
 
   pskl.utils.inherit(ns.BaseTool, pskl.tools.Tool);
 
-  ns.BaseTool.prototype.applyToolAt = function (col, row, color, frame, overlay, event) {};
+  ns.BaseTool.prototype.applyToolAt = function (col, row, frame, overlay, event) {};
 
-  ns.BaseTool.prototype.moveToolAt = function (col, row, color, frame, overlay, event) {};
+  ns.BaseTool.prototype.moveToolAt = function (col, row, frame, overlay, event) {};
 
   ns.BaseTool.prototype.replay = Constants.ABSTRACT_FUNCTION;
 
@@ -26,7 +26,7 @@
     return pskl.app.selectedColorsService.getPrimaryColor();
   };
 
-  ns.BaseTool.prototype.moveUnactiveToolAt = function (col, row, color, frame, overlay, event) {
+  ns.BaseTool.prototype.moveUnactiveToolAt = function (col, row, frame, overlay, event) {
     if (overlay.containsPixel(col, row)) {
       this.updateHighlightedPixel(frame, overlay, col, row);
     } else {
@@ -84,7 +84,7 @@
     });
   };
 
-  ns.BaseTool.prototype.releaseToolAt = function (col, row, color, frame, overlay, event) {};
+  ns.BaseTool.prototype.releaseToolAt = function (col, row, frame, overlay, event) {};
 
   /**
    * Bresenham line algorithm: Get an array of pixels from

--- a/src/js/tools/drawing/BaseTool.js
+++ b/src/js/tools/drawing/BaseTool.js
@@ -19,6 +19,13 @@
 
   ns.BaseTool.prototype.replay = Constants.ABSTRACT_FUNCTION;
 
+  ns.BaseTool.prototype.getToolColor = function() {
+    if (pskl.app.mouseStateService.isRightButtonPressed()) {
+      return pskl.app.selectedColorsService.getSecondaryColor();
+    }
+    return pskl.app.selectedColorsService.getPrimaryColor();
+  };
+
   ns.BaseTool.prototype.moveUnactiveToolAt = function (col, row, color, frame, overlay, event) {
     if (overlay.containsPixel(col, row)) {
       this.updateHighlightedPixel(frame, overlay, col, row);

--- a/src/js/tools/drawing/Circle.js
+++ b/src/js/tools/drawing/Circle.js
@@ -15,7 +15,10 @@
 
   pskl.utils.inherit(ns.Circle, ns.ShapeTool);
 
-  ns.Circle.prototype.draw_ = function (col, row, color, targetFrame) {
+  /**
+   * @override
+   */
+  ns.Circle.prototype.draw = function (col, row, color, targetFrame) {
     var circlePoints = this.getCirclePixels_(this.startCol, this.startRow, col, row);
     for (var i = 0 ; i < circlePoints.length ; i++) {
       // Change model:

--- a/src/js/tools/drawing/ColorPicker.js
+++ b/src/js/tools/drawing/ColorPicker.js
@@ -16,7 +16,7 @@
   /**
    * @override
    */
-  ns.ColorPicker.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.ColorPicker.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     if (frame.containsPixel(col, row)) {
       var sampledColor = frame.getPixel(col, row);
       if (event.button == Constants.LEFT_BUTTON) {

--- a/src/js/tools/drawing/ColorPicker.js
+++ b/src/js/tools/drawing/ColorPicker.js
@@ -16,7 +16,7 @@
   /**
    * @override
    */
-  ns.ColorPicker.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.ColorPicker.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
     if (frame.containsPixel(col, row)) {
       var sampledColor = frame.getPixel(col, row);
       if (event.button == Constants.LEFT_BUTTON) {

--- a/src/js/tools/drawing/ColorPicker.js
+++ b/src/js/tools/drawing/ColorPicker.js
@@ -19,9 +19,9 @@
   ns.ColorPicker.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     if (frame.containsPixel(col, row)) {
       var sampledColor = frame.getPixel(col, row);
-      if (event.button == Constants.LEFT_BUTTON) {
+      if (pskl.app.mouseStateService.isLeftButtonPressed()) {
         $.publish(Events.SELECT_PRIMARY_COLOR, [sampledColor]);
-      } else if (event.button == Constants.RIGHT_BUTTON) {
+      } else if (pskl.app.mouseStateService.isRightButtonPressed()) {
         $.publish(Events.SELECT_SECONDARY_COLOR, [sampledColor]);
       }
     }

--- a/src/js/tools/drawing/ColorSwap.js
+++ b/src/js/tools/drawing/ColorSwap.js
@@ -21,7 +21,7 @@
   /**
    * @override
    */
-  ns.ColorSwap.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.ColorSwap.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     if (frame.containsPixel(col, row)) {
       var sampledColor = frame.getPixel(col, row);
 

--- a/src/js/tools/drawing/ColorSwap.js
+++ b/src/js/tools/drawing/ColorSwap.js
@@ -21,14 +21,14 @@
   /**
    * @override
    */
-  ns.ColorSwap.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.ColorSwap.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
     if (frame.containsPixel(col, row)) {
       var sampledColor = frame.getPixel(col, row);
 
       var allLayers = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;
       var allFrames = event.shiftKey;
 
-      this.swapColors(sampledColor, color, allLayers, allFrames);
+      this.swapColors(sampledColor, this.getToolColor(), allLayers, allFrames);
 
       $.publish(Events.PISKEL_SAVE_STATE, {
         type : pskl.service.HistoryService.SNAPSHOT

--- a/src/js/tools/drawing/DitheringTool.js
+++ b/src/js/tools/drawing/DitheringTool.js
@@ -29,9 +29,9 @@
   /**
    * @override
    */
-  ns.DitheringTool.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.DitheringTool.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     this.col_ = col;
     this.row_ = row;
-    this.superclass.applyToolAt.call(this, col, row, color_legacy, frame, overlay, event);
+    this.superclass.applyToolAt.call(this, col, row, frame, overlay, event);
   };
 })();

--- a/src/js/tools/drawing/DitheringTool.js
+++ b/src/js/tools/drawing/DitheringTool.js
@@ -16,22 +16,22 @@
   /**
    * @override
    */
-  ns.DitheringTool.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
-    // On Firefox/IE, the clicked button type is not part of the mousemove event.
-    // Ensure we record the pressed button on the initial mousedown only.
-    if (event.type == 'mousedown') {
-      this.invertColors_ = event.button === Constants.RIGHT_BUTTON;
-    }
-
-    // Use primary selected color on cell with either an odd col or row.
-    // Use secondary color otherwise.
-    // When using the right mouse button, invert the above behavior to allow quick corrections.
-    var usePrimaryColor = (col + row) % 2;
-    usePrimaryColor = this.invertColors_ ? !usePrimaryColor : usePrimaryColor;
-
+  ns.DitheringTool.prototype.getToolColor = function() {
+    var usePrimaryColor = (this.col_ + this.row_) % 2;
+    usePrimaryColor =
+      pskl.app.mouseStateService.isRightButtonPressed() ? !usePrimaryColor : usePrimaryColor;
     var ditheringColor = usePrimaryColor ?
-        pskl.app.selectedColorsService.getPrimaryColor() :
-        pskl.app.selectedColorsService.getSecondaryColor();
-    this.superclass.applyToolAt.call(this, col, row, ditheringColor, frame, overlay, event);
+      pskl.app.selectedColorsService.getPrimaryColor() :
+      pskl.app.selectedColorsService.getSecondaryColor();
+    return ditheringColor;
+  };
+
+  /**
+   * @override
+   */
+  ns.DitheringTool.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+    this.col_ = col;
+    this.row_ = row;
+    this.superclass.applyToolAt.call(this, col, row, color_legacy, frame, overlay, event);
   };
 })();

--- a/src/js/tools/drawing/DitheringTool.js
+++ b/src/js/tools/drawing/DitheringTool.js
@@ -29,8 +29,9 @@
     var usePrimaryColor = (col + row) % 2;
     usePrimaryColor = this.invertColors_ ? !usePrimaryColor : usePrimaryColor;
 
-    var selectedColors = pskl.app.selectedColorsService.getColors();
-    var ditheringColor = usePrimaryColor ? selectedColors[0] : selectedColors[1];
+    var ditheringColor = usePrimaryColor ?
+        pskl.app.selectedColorsService.getPrimaryColor() :
+        pskl.app.selectedColorsService.getSecondaryColor();
     this.superclass.applyToolAt.call(this, col, row, ditheringColor, frame, overlay, event);
   };
 })();

--- a/src/js/tools/drawing/DitheringTool.js
+++ b/src/js/tools/drawing/DitheringTool.js
@@ -16,22 +16,14 @@
   /**
    * @override
    */
-  ns.DitheringTool.prototype.getToolColor = function() {
-    var usePrimaryColor = (this.col_ + this.row_) % 2;
+  ns.DitheringTool.prototype.applyToolAt = function(col, row, frame, overlay, event) {
+    var usePrimaryColor = (col + row) % 2;
     usePrimaryColor =
       pskl.app.mouseStateService.isRightButtonPressed() ? !usePrimaryColor : usePrimaryColor;
     var ditheringColor = usePrimaryColor ?
       pskl.app.selectedColorsService.getPrimaryColor() :
       pskl.app.selectedColorsService.getSecondaryColor();
-    return ditheringColor;
-  };
 
-  /**
-   * @override
-   */
-  ns.DitheringTool.prototype.applyToolAt = function(col, row, frame, overlay, event) {
-    this.col_ = col;
-    this.row_ = row;
-    this.superclass.applyToolAt.call(this, col, row, frame, overlay, event);
+    this.draw(ditheringColor, col, row, frame, overlay);
   };
 })();

--- a/src/js/tools/drawing/Eraser.js
+++ b/src/js/tools/drawing/Eraser.js
@@ -18,13 +18,7 @@
   /**
    * @override
    */
-  ns.Eraser.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
-    this.superclass.applyToolAt.call(this, col, row, Constants.TRANSPARENT_COLOR, frame, overlay, event);
-  };
-  /**
-   * @override
-   */
-  ns.Eraser.prototype.releaseToolAt = function(col, row, color, frame, overlay, event) {
-    this.superclass.releaseToolAt.call(this, col, row, Constants.TRANSPARENT_COLOR, frame, overlay, event);
+  ns.Eraser.prototype.getToolColor = function() {
+    return Constants.TRANSPARENT_COLOR;
   };
 })();

--- a/src/js/tools/drawing/Lighten.js
+++ b/src/js/tools/drawing/Lighten.js
@@ -66,17 +66,17 @@
   /**
    * @Override
    */
-  ns.Lighten.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event, mouseButton) {
+  ns.Lighten.prototype.applyToolAt = function(col, row, frame, overlay, event, mouseButton) {
     var overlayColor = overlay.getPixel(col, row);
     var frameColor = frame.getPixel(col, row);
 
     this.col_ = col;
     this.row_ = row;
     this.pixelColor_ = overlayColor === Constants.TRANSPARENT_COLOR ? frameColor : overlayColor;
-    this.isDarken_ = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;;
+    this.isDarken_ = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;
     this.isTransparent_ = this.pixelColor_ === Constants.TRANSPARENT_COLOR;
     this.isSinglePass_ = event.shiftKey;
 
-    this.superclass.applyToolAt.call(this, col, row, color_legacy, frame, overlay, event);
+    this.superclass.applyToolAt.call(this, col, row, frame, overlay, event);
   };
 })();

--- a/src/js/tools/drawing/Lighten.js
+++ b/src/js/tools/drawing/Lighten.js
@@ -69,16 +69,9 @@
         color = window.tinycolor.lighten(pixelColor, step);
       }
     }
-    if (color) {
-      // Convert tinycolor color to string format.
-      color = color.toRgbString();
-    } else {
-      // Not sure why this check exists in the first place.
-      // Fallback to the always defined SimplePen tool color in this case.
-      color = this.getToolColor();
-    }
     usedPixels[key] = true;
 
-    return color;
+    // Convert tinycolor color to string format.
+    return color.toRgbString();
   };
 })();

--- a/src/js/tools/drawing/Lighten.js
+++ b/src/js/tools/drawing/Lighten.js
@@ -41,42 +41,44 @@
   /**
    * @Override
    */
-  ns.Lighten.prototype.getToolColor = function() {
-    var color = this.superclass.getToolColor.call();
+  ns.Lighten.prototype.applyToolAt = function(col, row, frame, overlay, event, mouseButton) {
+    var modifiedColor = this.getModifiedColor_(col, row, frame, overlay, event);
+    this.draw(modifiedColor, col, row, frame, overlay);
+  };
 
-    var usedPixels = this.isDarken_ ? this.usedPixels_.darken : this.usedPixels_.lighten;
-    var key = this.col_ + '-' + this.row_;
-    var doNotModify = this.isTransparent_ || (this.isSinglePass_ && usedPixels[key]);
+  ns.Lighten.prototype.getModifiedColor_ = function(col, row, frame, overlay, event) {
+    var overlayColor = overlay.getPixel(col, row);
+    var frameColor = frame.getPixel(col, row);
+    var pixelColor = overlayColor === Constants.TRANSPARENT_COLOR ? frameColor : overlayColor;
+    var isDarken = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;
+    var isTransparent = pixelColor === Constants.TRANSPARENT_COLOR;
+    var isSinglePass = event.shiftKey;
+
+    var usedPixels = isDarken ? this.usedPixels_.darken : this.usedPixels_.lighten;
+    var key = col + '-' + row;
+    var doNotModify = isTransparent || (isSinglePass && usedPixels[key]);
+
+    var color;
     if (doNotModify) {
-      color = window.tinycolor(this.pixelColor_);
+      color = window.tinycolor(pixelColor);
     } else {
-      var step = this.isSinglePass_ ? DEFAULT_STEP * 2 : DEFAULT_STEP;
-      if (this.isDarken_) {
-        color = window.tinycolor.darken(this.pixelColor_, step);
+      var step = isSinglePass ? DEFAULT_STEP * 2 : DEFAULT_STEP;
+      if (isDarken) {
+        color = window.tinycolor.darken(pixelColor, step);
       } else {
-        color = window.tinycolor.lighten(this.pixelColor_, step);
+        color = window.tinycolor.lighten(pixelColor, step);
       }
     }
     if (color) {
-      usedPixels[key] = true;
+      // Convert tinycolor color to string format.
+      color = color.toRgbString();
+    } else {
+      // Not sure why this check exists in the first place.
+      // Fallback to the always defined SimplePen tool color in this case.
+      color = this.getToolColor();
     }
-    return color.toRgbString();
-  };
+    usedPixels[key] = true;
 
-  /**
-   * @Override
-   */
-  ns.Lighten.prototype.applyToolAt = function(col, row, frame, overlay, event, mouseButton) {
-    var overlayColor = overlay.getPixel(col, row);
-    var frameColor = frame.getPixel(col, row);
-
-    this.col_ = col;
-    this.row_ = row;
-    this.pixelColor_ = overlayColor === Constants.TRANSPARENT_COLOR ? frameColor : overlayColor;
-    this.isDarken_ = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;
-    this.isTransparent_ = this.pixelColor_ === Constants.TRANSPARENT_COLOR;
-    this.isSinglePass_ = event.shiftKey;
-
-    this.superclass.applyToolAt.call(this, col, row, frame, overlay, event);
+    return color;
   };
 })();

--- a/src/js/tools/drawing/Move.js
+++ b/src/js/tools/drawing/Move.js
@@ -28,14 +28,14 @@
   /**
    * @override
    */
-  ns.Move.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.Move.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     this.startCol = col;
     this.startRow = row;
     this.currentFrame = frame;
     this.currentFrameClone = frame.clone();
   };
 
-  ns.Move.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.Move.prototype.moveToolAt = function(col, row, frame, overlay, event) {
     var colDiff = col - this.startCol;
     var rowDiff = row - this.startRow;
     this.shiftFrame(colDiff, rowDiff, frame, this.currentFrameClone, event);
@@ -66,7 +66,7 @@
   /**
    * @override
    */
-  ns.Move.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.Move.prototype.releaseToolAt = function(col, row, frame, overlay, event) {
     var colDiff = col - this.startCol;
     var rowDiff = row - this.startRow;
 

--- a/src/js/tools/drawing/Move.js
+++ b/src/js/tools/drawing/Move.js
@@ -28,14 +28,14 @@
   /**
    * @override
    */
-  ns.Move.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.Move.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
     this.startCol = col;
     this.startRow = row;
     this.currentFrame = frame;
     this.currentFrameClone = frame.clone();
   };
 
-  ns.Move.prototype.moveToolAt = function(col, row, color, frame, overlay, event) {
+  ns.Move.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
     var colDiff = col - this.startCol;
     var rowDiff = row - this.startRow;
     this.shiftFrame(colDiff, rowDiff, frame, this.currentFrameClone, event);
@@ -66,7 +66,7 @@
   /**
    * @override
    */
-  ns.Move.prototype.releaseToolAt = function(col, row, color, frame, overlay, event) {
+  ns.Move.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
     var colDiff = col - this.startCol;
     var rowDiff = row - this.startRow;
 

--- a/src/js/tools/drawing/PaintBucket.js
+++ b/src/js/tools/drawing/PaintBucket.js
@@ -16,7 +16,8 @@
   /**
    * @override
    */
-  ns.PaintBucket.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.PaintBucket.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+    var color = this.getToolColor();
     pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(frame, col, row, color);
 
     this.raiseSaveStateEvent({

--- a/src/js/tools/drawing/PaintBucket.js
+++ b/src/js/tools/drawing/PaintBucket.js
@@ -16,7 +16,7 @@
   /**
    * @override
    */
-  ns.PaintBucket.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.PaintBucket.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     var color = this.getToolColor();
     pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(frame, col, row, color);
 

--- a/src/js/tools/drawing/Rectangle.js
+++ b/src/js/tools/drawing/Rectangle.js
@@ -16,11 +16,11 @@
 
   pskl.utils.inherit(ns.Rectangle, ns.ShapeTool);
 
-  ns.Rectangle.prototype.draw_ = function (col, row, color, targetFrame) {
+  ns.Rectangle.prototype.draw_ = function (col, row, color_legacy, targetFrame) {
     var strokePoints = pskl.PixelUtils.getBoundRectanglePixels(this.startCol, this.startRow, col, row);
     for (var i = 0 ; i < strokePoints.length ; i++) {
       // Change model:
-      targetFrame.setPixel(strokePoints[i].col, strokePoints[i].row, color);
+      targetFrame.setPixel(strokePoints[i].col, strokePoints[i].row, this.getToolColor());
     }
   };
 })();

--- a/src/js/tools/drawing/Rectangle.js
+++ b/src/js/tools/drawing/Rectangle.js
@@ -16,7 +16,10 @@
 
   pskl.utils.inherit(ns.Rectangle, ns.ShapeTool);
 
-  ns.Rectangle.prototype.draw_ = function (col, row, color_legacy, targetFrame) {
+  /**
+   * @override
+   */
+  ns.Rectangle.prototype.draw = function (col, row, color, targetFrame) {
     var strokePoints = pskl.PixelUtils.getBoundRectanglePixels(this.startCol, this.startRow, col, row);
     for (var i = 0 ; i < strokePoints.length ; i++) {
       // Change model:

--- a/src/js/tools/drawing/Rectangle.js
+++ b/src/js/tools/drawing/Rectangle.js
@@ -10,7 +10,6 @@
     ns.ShapeTool.call(this);
 
     this.toolId = 'tool-rectangle';
-
     this.helpText = 'Rectangle tool';
   };
 
@@ -23,7 +22,7 @@
     var strokePoints = pskl.PixelUtils.getBoundRectanglePixels(this.startCol, this.startRow, col, row);
     for (var i = 0 ; i < strokePoints.length ; i++) {
       // Change model:
-      targetFrame.setPixel(strokePoints[i].col, strokePoints[i].row, this.getToolColor());
+      targetFrame.setPixel(strokePoints[i].col, strokePoints[i].row, color);
     }
   };
 })();

--- a/src/js/tools/drawing/ShapeTool.js
+++ b/src/js/tools/drawing/ShapeTool.js
@@ -2,7 +2,7 @@
   var ns = $.namespace('pskl.tools.drawing');
   /**
    * Abstract shape tool class, parent to all shape tools (rectangle, circle).
-   * Shape tools should override only the draw_ method
+   * Shape tools should override only the draw method
    */
   ns.ShapeTool = function() {
     // Shapes's first point coordinates (set in applyToolAt)
@@ -19,7 +19,7 @@
   /**
    * @override
    */
-  ns.ShapeTool.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.ShapeTool.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     $.publish(Events.DRAG_START, [col, row]);
     this.startCol = col;
     this.startRow = row;
@@ -28,7 +28,7 @@
     overlay.setPixel(col, row, this.getToolColor());
   };
 
-  ns.ShapeTool.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.ShapeTool.prototype.moveToolAt = function(col, row, frame, overlay, event) {
     var coords = this.getCoordinates_(col, row, event);
     $.publish(Events.CURSOR_MOVED, [coords.col, coords.row]);
 
@@ -39,17 +39,17 @@
     }
 
     // draw in overlay
-    this.draw_(coords.col, coords.row, color, overlay);
+    this.draw(coords.col, coords.row, color, overlay);
   };
 
   /**
    * @override
    */
-  ns.ShapeTool.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.ShapeTool.prototype.releaseToolAt = function(col, row, frame, overlay, event) {
     overlay.clear();
     var coords = this.getCoordinates_(col, row, event);
     var color = this.getToolColor();
-    this.draw_(coords.col, coords.row, color, frame);
+    this.draw(coords.col, coords.row, color, frame);
 
     $.publish(Events.DRAG_END, [coords.col, coords.row]);
     this.raiseSaveStateEvent({
@@ -67,7 +67,7 @@
   ns.ShapeTool.prototype.replay = function(frame, replayData) {
     this.startCol = replayData.startCol;
     this.startRow = replayData.startRow;
-    this.draw_(replayData.col, replayData.row, replayData.color, frame);
+    this.draw(replayData.col, replayData.row, replayData.color, frame);
   };
 
   /**
@@ -108,6 +108,6 @@
     };
   };
 
-  ns.ShapeTool.prototype.draw_ = Constants.ABSTRACT_FUNCTION;
+  ns.ShapeTool.prototype.draw = Constants.ABSTRACT_FUNCTION;
 
 })();

--- a/src/js/tools/drawing/ShapeTool.js
+++ b/src/js/tools/drawing/ShapeTool.js
@@ -19,20 +19,21 @@
   /**
    * @override
    */
-  ns.ShapeTool.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.ShapeTool.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
     $.publish(Events.DRAG_START, [col, row]);
     this.startCol = col;
     this.startRow = row;
 
     // Drawing the first point of the rectangle in the fake overlay canvas:
-    overlay.setPixel(col, row, color);
+    overlay.setPixel(col, row, this.getToolColor());
   };
 
-  ns.ShapeTool.prototype.moveToolAt = function(col, row, color, frame, overlay, event) {
+  ns.ShapeTool.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
     var coords = this.getCoordinates_(col, row, event);
     $.publish(Events.CURSOR_MOVED, [coords.col, coords.row]);
 
     overlay.clear();
+    var color = this.getToolColor();
     if (color == Constants.TRANSPARENT_COLOR) {
       color = Constants.SELECTION_TRANSPARENT_COLOR;
     }
@@ -44,9 +45,10 @@
   /**
    * @override
    */
-  ns.ShapeTool.prototype.releaseToolAt = function(col, row, color, frame, overlay, event) {
+  ns.ShapeTool.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
     overlay.clear();
     var coords = this.getCoordinates_(col, row, event);
+    var color = this.getToolColor();
     this.draw_(coords.col, coords.row, color, frame);
 
     $.publish(Events.DRAG_END, [coords.col, coords.row]);

--- a/src/js/tools/drawing/SimplePen.js
+++ b/src/js/tools/drawing/SimplePen.js
@@ -21,10 +21,10 @@
   /**
    * @override
    */
-  ns.SimplePen.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.SimplePen.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
     this.previousCol = col;
     this.previousRow = row;
-
+    var color =  this.getToolColor();
     overlay.setPixel(col, row, color);
 
     if (color === Constants.TRANSPARENT_COLOR) {
@@ -40,7 +40,7 @@
   /**
    * @override
    */
-  ns.SimplePen.prototype.moveToolAt = function(col, row, color, frame, overlay, event) {
+  ns.SimplePen.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
     if ((Math.abs(col - this.previousCol) > 1) || (Math.abs(row - this.previousRow) > 1)) {
       // The pen movement is too fast for the mousemove frequency, there is a gap between the
       // current point and the previously drawn one.
@@ -48,24 +48,24 @@
       var interpolatedPixels = this.getLinePixels_(col, this.previousCol, row, this.previousRow);
       for (var i = 0, l = interpolatedPixels.length ; i < l ; i++) {
         var coords = interpolatedPixels[i];
-        this.applyToolAt(coords.col, coords.row, color, frame, overlay, event);
+        this.applyToolAt(coords.col, coords.row, color_legacy, frame, overlay, event);
       }
     } else {
-      this.applyToolAt(col, row, color, frame, overlay, event);
+      this.applyToolAt(col, row, color_legacy, frame, overlay, event);
     }
 
     this.previousCol = col;
     this.previousRow = row;
   };
 
-  ns.SimplePen.prototype.releaseToolAt = function(col, row, color, frame, overlay, event) {
+  ns.SimplePen.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
     // apply on real frame
     this.setPixelsToFrame_(frame, this.pixels);
 
     // save state
     this.raiseSaveStateEvent({
       pixels : this.pixels.slice(0),
-      color : color
+      color : this.getToolColor()
     });
 
     // reset

--- a/src/js/tools/drawing/SimplePen.js
+++ b/src/js/tools/drawing/SimplePen.js
@@ -22,11 +22,15 @@
    * @override
    */
   ns.SimplePen.prototype.applyToolAt = function(col, row, frame, overlay, event) {
+    var color = this.getToolColor();
+    this.draw(color, col, row, frame, overlay);
+  };
+
+  ns.SimplePen.prototype.draw = function(color, col, row, frame, overlay) {
     this.previousCol = col;
     this.previousRow = row;
-    var color = this.getToolColor();
-    overlay.setPixel(col, row, color);
 
+    overlay.setPixel(col, row, color);
     if (color === Constants.TRANSPARENT_COLOR) {
       frame.setPixel(col, row, color);
     }

--- a/src/js/tools/drawing/SimplePen.js
+++ b/src/js/tools/drawing/SimplePen.js
@@ -21,10 +21,10 @@
   /**
    * @override
    */
-  ns.SimplePen.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.SimplePen.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     this.previousCol = col;
     this.previousRow = row;
-    var color =  this.getToolColor();
+    var color = this.getToolColor();
     overlay.setPixel(col, row, color);
 
     if (color === Constants.TRANSPARENT_COLOR) {
@@ -40,7 +40,7 @@
   /**
    * @override
    */
-  ns.SimplePen.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.SimplePen.prototype.moveToolAt = function(col, row, frame, overlay, event) {
     if ((Math.abs(col - this.previousCol) > 1) || (Math.abs(row - this.previousRow) > 1)) {
       // The pen movement is too fast for the mousemove frequency, there is a gap between the
       // current point and the previously drawn one.
@@ -48,17 +48,17 @@
       var interpolatedPixels = this.getLinePixels_(col, this.previousCol, row, this.previousRow);
       for (var i = 0, l = interpolatedPixels.length ; i < l ; i++) {
         var coords = interpolatedPixels[i];
-        this.applyToolAt(coords.col, coords.row, color_legacy, frame, overlay, event);
+        this.applyToolAt(coords.col, coords.row, frame, overlay, event);
       }
     } else {
-      this.applyToolAt(col, row, color_legacy, frame, overlay, event);
+      this.applyToolAt(col, row, frame, overlay, event);
     }
 
     this.previousCol = col;
     this.previousRow = row;
   };
 
-  ns.SimplePen.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.SimplePen.prototype.releaseToolAt = function(col, row, frame, overlay, event) {
     // apply on real frame
     this.setPixelsToFrame_(frame, this.pixels);
 

--- a/src/js/tools/drawing/Stroke.js
+++ b/src/js/tools/drawing/Stroke.js
@@ -20,7 +20,7 @@
   /**
    * @override
    */
-  ns.Stroke.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.Stroke.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
     this.startCol = col;
     this.startRow = row;
 
@@ -33,10 +33,10 @@
 
     // The fake canvas where we will draw the preview of the stroke:
     // Drawing the first point of the stroke in the fake overlay canvas:
-    overlay.setPixel(col, row, color);
+    overlay.setPixel(col, row, this.getToolColor());
   };
 
-  ns.Stroke.prototype.moveToolAt = function(col, row, color, frame, overlay, event) {
+  ns.Stroke.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
     overlay.clear();
 
     // When the user moussemove (before releasing), we dynamically compute the
@@ -44,6 +44,7 @@
     var strokePoints = this.getLinePixels_(this.startCol, col, this.startRow, row);
 
     // Drawing current stroke:
+    var color = this.getToolColor();
     for (var i = 0; i < strokePoints.length; i++) {
 
       if (color == Constants.TRANSPARENT_COLOR) {
@@ -62,7 +63,8 @@
   /**
    * @override
    */
-  ns.Stroke.prototype.releaseToolAt = function(col, row, color, frame, overlay, event) {
+  ns.Stroke.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
+    var color = this.getToolColor();
     // The user released the tool to draw a line. We will compute the pixel coordinate, impact
     // the model and draw them in the drawing canvas (not the fake overlay anymore)
     var strokePoints = this.getLinePixels_(this.startCol, col, this.startRow, row);

--- a/src/js/tools/drawing/Stroke.js
+++ b/src/js/tools/drawing/Stroke.js
@@ -20,7 +20,7 @@
   /**
    * @override
    */
-  ns.Stroke.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.Stroke.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     this.startCol = col;
     this.startRow = row;
 
@@ -36,7 +36,7 @@
     overlay.setPixel(col, row, this.getToolColor());
   };
 
-  ns.Stroke.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.Stroke.prototype.moveToolAt = function(col, row, frame, overlay, event) {
     overlay.clear();
 
     // When the user moussemove (before releasing), we dynamically compute the
@@ -63,7 +63,7 @@
   /**
    * @override
    */
-  ns.Stroke.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.Stroke.prototype.releaseToolAt = function(col, row, frame, overlay, event) {
     var color = this.getToolColor();
     // The user released the tool to draw a line. We will compute the pixel coordinate, impact
     // the model and draw them in the drawing canvas (not the fake overlay anymore)

--- a/src/js/tools/drawing/VerticalMirrorPen.js
+++ b/src/js/tools/drawing/VerticalMirrorPen.js
@@ -28,8 +28,8 @@
   /**
    * @override
    */
-  ns.VerticalMirrorPen.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
-    this.superclass.applyToolAt.call(this, col, row, color_legacy, frame, overlay);
+  ns.VerticalMirrorPen.prototype.applyToolAt = function(col, row, frame, overlay, event) {
+    this.superclass.applyToolAt.call(this, col, row, frame, overlay);
     this.backupPreviousPositions_();
 
     var mirroredCol = this.getSymmetricCol_(col, frame);
@@ -37,15 +37,15 @@
 
     var hasCtrlKey = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;
     if (!hasCtrlKey) {
-      this.superclass.applyToolAt.call(this, mirroredCol, row, color_legacy, frame, overlay);
+      this.superclass.applyToolAt.call(this, mirroredCol, row, frame, overlay);
     }
 
     if (event.shiftKey || hasCtrlKey) {
-      this.superclass.applyToolAt.call(this, col, mirroredRow, color_legacy, frame, overlay);
+      this.superclass.applyToolAt.call(this, col, mirroredRow, frame, overlay);
     }
 
     if (event.shiftKey) {
-      this.superclass.applyToolAt.call(this, mirroredCol, mirroredRow, color_legacy, frame, overlay);
+      this.superclass.applyToolAt.call(this, mirroredCol, mirroredRow, frame, overlay);
     }
 
     this.restorePreviousPositions_();

--- a/src/js/tools/drawing/VerticalMirrorPen.js
+++ b/src/js/tools/drawing/VerticalMirrorPen.js
@@ -28,8 +28,8 @@
   /**
    * @override
    */
-  ns.VerticalMirrorPen.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
-    this.superclass.applyToolAt.call(this, col, row, color, frame, overlay);
+  ns.VerticalMirrorPen.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+    this.superclass.applyToolAt.call(this, col, row, color_legacy, frame, overlay);
     this.backupPreviousPositions_();
 
     var mirroredCol = this.getSymmetricCol_(col, frame);
@@ -37,15 +37,15 @@
 
     var hasCtrlKey = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;
     if (!hasCtrlKey) {
-      this.superclass.applyToolAt.call(this, mirroredCol, row, color, frame, overlay);
+      this.superclass.applyToolAt.call(this, mirroredCol, row, color_legacy, frame, overlay);
     }
 
     if (event.shiftKey || hasCtrlKey) {
-      this.superclass.applyToolAt.call(this, col, mirroredRow, color, frame, overlay);
+      this.superclass.applyToolAt.call(this, col, mirroredRow, color_legacy, frame, overlay);
     }
 
     if (event.shiftKey) {
-      this.superclass.applyToolAt.call(this, mirroredCol, mirroredRow, color, frame, overlay);
+      this.superclass.applyToolAt.call(this, mirroredCol, mirroredRow, color_legacy, frame, overlay);
     }
 
     this.restorePreviousPositions_();

--- a/src/js/tools/drawing/VerticalMirrorPen.js
+++ b/src/js/tools/drawing/VerticalMirrorPen.js
@@ -29,7 +29,9 @@
    * @override
    */
   ns.VerticalMirrorPen.prototype.applyToolAt = function(col, row, frame, overlay, event) {
-    this.superclass.applyToolAt.call(this, col, row, frame, overlay);
+    var color = this.getToolColor();
+    this.draw(color, col, row, frame, overlay);
+
     this.backupPreviousPositions_();
 
     var mirroredCol = this.getSymmetricCol_(col, frame);
@@ -37,15 +39,15 @@
 
     var hasCtrlKey = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;
     if (!hasCtrlKey) {
-      this.superclass.applyToolAt.call(this, mirroredCol, row, frame, overlay);
+      this.draw(color, mirroredCol, row, frame, overlay);
     }
 
     if (event.shiftKey || hasCtrlKey) {
-      this.superclass.applyToolAt.call(this, col, mirroredRow, frame, overlay);
+      this.draw(color, col, mirroredRow, frame, overlay);
     }
 
     if (event.shiftKey) {
-      this.superclass.applyToolAt.call(this, mirroredCol, mirroredRow, frame, overlay);
+      this.draw(color, mirroredCol, mirroredRow, frame, overlay);
     }
 
     this.restorePreviousPositions_();

--- a/src/js/tools/drawing/selection/BaseSelect.js
+++ b/src/js/tools/drawing/selection/BaseSelect.js
@@ -28,7 +28,7 @@
   /**
    * @override
    */
-  ns.BaseSelect.prototype.applyToolAt = function(col, row, color, frame, overlay, event) {
+  ns.BaseSelect.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
     this.startCol = col;
     this.startRow = row;
 
@@ -42,32 +42,32 @@
     // mode to allow to move the selection by drag'n dropping it.
     if (this.isInSelection(col, row)) {
       this.mode = 'moveSelection';
-      this.onSelectionDragStart_(col, row, color, frame, overlay);
+      this.onSelectionDragStart_(col, row, color_legacy, frame, overlay);
     } else {
       this.mode = 'select';
-      this.onSelectStart_(col, row, color, frame, overlay);
+      this.onSelectStart_(col, row, color_legacy, frame, overlay);
     }
   };
 
   /**
    * @override
    */
-  ns.BaseSelect.prototype.moveToolAt = function(col, row, color, frame, overlay, event) {
+  ns.BaseSelect.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
     if (this.mode == 'select') {
-      this.onSelect_(col, row, color, frame, overlay);
+      this.onSelect_(col, row, color_legacy, frame, overlay);
     } else if (this.mode == 'moveSelection') {
-      this.onSelectionDrag_(col, row, color, frame, overlay);
+      this.onSelectionDrag_(col, row, color_legacy, frame, overlay);
     }
   };
 
   /**
    * @override
    */
-  ns.BaseSelect.prototype.releaseToolAt = function(col, row, color, frame, overlay, event) {
+  ns.BaseSelect.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
     if (this.mode == 'select') {
-      this.onSelectEnd_(col, row, color, frame, overlay);
+      this.onSelectEnd_(col, row, color_legacy, frame, overlay);
     } else if (this.mode == 'moveSelection') {
-      this.onSelectionDragEnd_(col, row, color, frame, overlay);
+      this.onSelectionDragEnd_(col, row, color_legacy, frame, overlay);
     }
   };
 
@@ -76,7 +76,7 @@
    * instead of the 'select' one. It indicates that we can move the selection by dragndroping it.
    * @override
    */
-  ns.BaseSelect.prototype.moveUnactiveToolAt = function(col, row, color, frame, overlay, event) {
+  ns.BaseSelect.prototype.moveUnactiveToolAt = function(col, row, color_legacy, frame, overlay, event) {
     if (overlay.containsPixel(col, row)) {
       if (this.isInSelection(col, row)) {
         // We're hovering the selection, show the move tool:
@@ -124,18 +124,18 @@
 
   // The list of callbacks to implement by specialized tools to implement the selection creation behavior.
   /** @protected */
-  ns.BaseSelect.prototype.onSelectStart_ = function (col, row, color, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelectStart_ = function (col, row, color_legacy, frame, overlay) {};
   /** @protected */
-  ns.BaseSelect.prototype.onSelect_ = function (col, row, color, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelect_ = function (col, row, color_legacy, frame, overlay) {};
   /** @protected */
-  ns.BaseSelect.prototype.onSelectEnd_ = function (col, row, color, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelectEnd_ = function (col, row, color_legacy, frame, overlay) {};
 
   // The list of callbacks that define the drag'n drop behavior of the selection.
   /** @private */
-  ns.BaseSelect.prototype.onSelectionDragStart_ = function (col, row, color, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelectionDragStart_ = function (col, row, color_legacy, frame, overlay) {};
 
   /** @private */
-  ns.BaseSelect.prototype.onSelectionDrag_ = function (col, row, color, frame, overlay) {
+  ns.BaseSelect.prototype.onSelectionDrag_ = function (col, row, color_legacy, frame, overlay) {
     var deltaCol = col - this.lastCol;
     var deltaRow = row - this.lastRow;
 
@@ -152,7 +152,7 @@
   };
 
   /** @private */
-  ns.BaseSelect.prototype.onSelectionDragEnd_ = function (col, row, color, frame, overlay) {
-    this.onSelectionDrag_(col, row, color, frame, overlay);
+  ns.BaseSelect.prototype.onSelectionDragEnd_ = function (col, row, color_legacy, frame, overlay) {
+    this.onSelectionDrag_(col, row, color_legacy, frame, overlay);
   };
 })();

--- a/src/js/tools/drawing/selection/BaseSelect.js
+++ b/src/js/tools/drawing/selection/BaseSelect.js
@@ -28,7 +28,7 @@
   /**
    * @override
    */
-  ns.BaseSelect.prototype.applyToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.BaseSelect.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     this.startCol = col;
     this.startRow = row;
 
@@ -42,32 +42,32 @@
     // mode to allow to move the selection by drag'n dropping it.
     if (this.isInSelection(col, row)) {
       this.mode = 'moveSelection';
-      this.onSelectionDragStart_(col, row, color_legacy, frame, overlay);
+      this.onSelectionDragStart_(col, row, frame, overlay);
     } else {
       this.mode = 'select';
-      this.onSelectStart_(col, row, color_legacy, frame, overlay);
+      this.onSelectStart_(col, row, frame, overlay);
     }
   };
 
   /**
    * @override
    */
-  ns.BaseSelect.prototype.moveToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.BaseSelect.prototype.moveToolAt = function(col, row, frame, overlay, event) {
     if (this.mode == 'select') {
-      this.onSelect_(col, row, color_legacy, frame, overlay);
+      this.onSelect_(col, row, frame, overlay);
     } else if (this.mode == 'moveSelection') {
-      this.onSelectionDrag_(col, row, color_legacy, frame, overlay);
+      this.onSelectionDrag_(col, row, frame, overlay);
     }
   };
 
   /**
    * @override
    */
-  ns.BaseSelect.prototype.releaseToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.BaseSelect.prototype.releaseToolAt = function(col, row, frame, overlay, event) {
     if (this.mode == 'select') {
-      this.onSelectEnd_(col, row, color_legacy, frame, overlay);
+      this.onSelectEnd_(col, row, frame, overlay);
     } else if (this.mode == 'moveSelection') {
-      this.onSelectionDragEnd_(col, row, color_legacy, frame, overlay);
+      this.onSelectionDragEnd_(col, row, frame, overlay);
     }
   };
 
@@ -76,7 +76,7 @@
    * instead of the 'select' one. It indicates that we can move the selection by dragndroping it.
    * @override
    */
-  ns.BaseSelect.prototype.moveUnactiveToolAt = function(col, row, color_legacy, frame, overlay, event) {
+  ns.BaseSelect.prototype.moveUnactiveToolAt = function(col, row, frame, overlay, event) {
     if (overlay.containsPixel(col, row)) {
       if (this.isInSelection(col, row)) {
         // We're hovering the selection, show the move tool:
@@ -124,18 +124,18 @@
 
   // The list of callbacks to implement by specialized tools to implement the selection creation behavior.
   /** @protected */
-  ns.BaseSelect.prototype.onSelectStart_ = function (col, row, color_legacy, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelectStart_ = function (col, row, frame, overlay) {};
   /** @protected */
-  ns.BaseSelect.prototype.onSelect_ = function (col, row, color_legacy, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelect_ = function (col, row, frame, overlay) {};
   /** @protected */
-  ns.BaseSelect.prototype.onSelectEnd_ = function (col, row, color_legacy, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelectEnd_ = function (col, row, frame, overlay) {};
 
   // The list of callbacks that define the drag'n drop behavior of the selection.
   /** @private */
-  ns.BaseSelect.prototype.onSelectionDragStart_ = function (col, row, color_legacy, frame, overlay) {};
+  ns.BaseSelect.prototype.onSelectionDragStart_ = function (col, row, frame, overlay) {};
 
   /** @private */
-  ns.BaseSelect.prototype.onSelectionDrag_ = function (col, row, color_legacy, frame, overlay) {
+  ns.BaseSelect.prototype.onSelectionDrag_ = function (col, row, frame, overlay) {
     var deltaCol = col - this.lastCol;
     var deltaRow = row - this.lastRow;
 
@@ -152,7 +152,7 @@
   };
 
   /** @private */
-  ns.BaseSelect.prototype.onSelectionDragEnd_ = function (col, row, color_legacy, frame, overlay) {
-    this.onSelectionDrag_(col, row, color_legacy, frame, overlay);
+  ns.BaseSelect.prototype.onSelectionDragEnd_ = function (col, row, frame, overlay) {
+    this.onSelectionDrag_(col, row, frame, overlay);
   };
 })();

--- a/src/js/tools/drawing/selection/RectangleSelect.js
+++ b/src/js/tools/drawing/selection/RectangleSelect.js
@@ -49,7 +49,7 @@
    * the current mouse coordiinate in sprite.
    * @override
    */
-  ns.RectangleSelect.prototype.onSelect_ = function (col, row, color, frame, overlay) {
+  ns.RectangleSelect.prototype.onSelect_ = function (col, row, color_legacy, frame, overlay) {
     if (!this.hasSelection && (this.selectionOrigin_.col !== col || this.selectionOrigin_.row !== row)) {
       this.startSelection_(col, row);
     }
@@ -63,9 +63,9 @@
     }
   };
 
-  ns.RectangleSelect.prototype.onSelectEnd_ = function (col, row, color, frame, overlay) {
+  ns.RectangleSelect.prototype.onSelectEnd_ = function (col, row, color_legacy, frame, overlay) {
     if (this.hasSelection) {
-      this.onSelect_(col, row, color, frame, overlay);
+      this.onSelect_(col, row, color_legacy, frame, overlay);
       $.publish(Events.DRAG_END, [col, row]);
     }
   };

--- a/src/js/tools/drawing/selection/RectangleSelect.js
+++ b/src/js/tools/drawing/selection/RectangleSelect.js
@@ -22,7 +22,7 @@
   /**
    * @override
    */
-  ns.RectangleSelect.prototype.onSelectStart_ = function (col, row, color, frame, overlay) {
+  ns.RectangleSelect.prototype.onSelectStart_ = function (col, row, frame, overlay) {
     this.selectionOrigin_ = {
       col : col,
       row : row
@@ -33,7 +33,7 @@
       $.publish(Events.SELECTION_DISMISSED);
     } else {
       this.startSelection_(col, row);
-      overlay.setPixel(col, row, color);
+      overlay.setPixel(col, row, Constants.SELECTION_TRANSPARENT_COLOR);
     }
   };
 
@@ -49,7 +49,7 @@
    * the current mouse coordiinate in sprite.
    * @override
    */
-  ns.RectangleSelect.prototype.onSelect_ = function (col, row, color_legacy, frame, overlay) {
+  ns.RectangleSelect.prototype.onSelect_ = function (col, row, frame, overlay) {
     if (!this.hasSelection && (this.selectionOrigin_.col !== col || this.selectionOrigin_.row !== row)) {
       this.startSelection_(col, row);
     }
@@ -63,9 +63,9 @@
     }
   };
 
-  ns.RectangleSelect.prototype.onSelectEnd_ = function (col, row, color_legacy, frame, overlay) {
+  ns.RectangleSelect.prototype.onSelectEnd_ = function (col, row, frame, overlay) {
     if (this.hasSelection) {
-      this.onSelect_(col, row, color_legacy, frame, overlay);
+      this.onSelect_(col, row, frame, overlay);
       $.publish(Events.DRAG_END, [col, row]);
     }
   };

--- a/src/js/tools/drawing/selection/ShapeSelect.js
+++ b/src/js/tools/drawing/selection/ShapeSelect.js
@@ -21,7 +21,7 @@
    * So we jsut need to implement onSelectStart_ (no need for onSelect_ & onSelectEnd_)
    * @override
    */
-  ns.ShapeSelect.prototype.onSelectStart_ = function (col, row, color, frame, overlay) {
+  ns.ShapeSelect.prototype.onSelectStart_ = function (col, row, color_legacy, frame, overlay) {
     // Clean previous selection:
     $.publish(Events.SELECTION_DISMISSED);
     overlay.clear();

--- a/src/js/tools/drawing/selection/ShapeSelect.js
+++ b/src/js/tools/drawing/selection/ShapeSelect.js
@@ -21,7 +21,7 @@
    * So we jsut need to implement onSelectStart_ (no need for onSelect_ & onSelectEnd_)
    * @override
    */
-  ns.ShapeSelect.prototype.onSelectStart_ = function (col, row, color_legacy, frame, overlay) {
+  ns.ShapeSelect.prototype.onSelectStart_ = function (col, row, frame, overlay) {
     // Clean previous selection:
     $.publish(Events.SELECTION_DISMISSED);
     overlay.clear();

--- a/src/js/tools/transform/AbstractTransformTool.js
+++ b/src/js/tools/transform/AbstractTransformTool.js
@@ -1,21 +1,17 @@
 (function () {
   var ns = $.namespace('pskl.tools.transform');
 
-  ns.Transform = function () {
-    this.toolId = 'tool-transform';
-    this.helpText = 'Transform tool';
-    this.tooltipDescriptors = [];
-  };
+  ns.AbstractTransformTool = function () {};
 
-  pskl.utils.inherit(ns.Transform, pskl.tools.Tool);
+  pskl.utils.inherit(ns.AbstractTransformTool, pskl.tools.Tool);
 
-  ns.Transform.prototype.apply = function (evt) {
+  ns.AbstractTransformTool.prototype.apply = function (evt) {
     var allFrames = evt.shiftKey;
     var allLayers = evt.ctrlKey;
     this.applyTool_(evt.altKey, allFrames, allLayers);
   };
 
-  ns.Transform.prototype.applyTool_ = function (altKey, allFrames, allLayers) {
+  ns.AbstractTransformTool.prototype.applyTool_ = function (altKey, allFrames, allLayers) {
     var currentFrameIndex = pskl.app.piskelController.getCurrentFrameIndex();
     var layers = allLayers ? pskl.app.piskelController.getLayers() : [pskl.app.piskelController.getCurrentLayer()];
     layers.forEach(function (layer) {

--- a/src/js/tools/transform/Clone.js
+++ b/src/js/tools/transform/Clone.js
@@ -7,7 +7,7 @@
     this.tooltipDescriptors = [];
   };
 
-  pskl.utils.inherit(ns.Clone, ns.Transform);
+  pskl.utils.inherit(ns.Clone, ns.AbstractTransformTool);
 
   ns.Clone.prototype.apply = function (evt) {
     var ref = pskl.app.piskelController.getCurrentFrame();

--- a/src/js/tools/transform/Flip.js
+++ b/src/js/tools/transform/Flip.js
@@ -11,18 +11,18 @@
     ];
   };
 
-  pskl.utils.inherit(ns.Flip, ns.Transform);
+  pskl.utils.inherit(ns.Flip, ns.AbstractTransformTool);
 
   ns.Flip.prototype.applyToolOnFrame_ = function (frame, altKey) {
     var axis;
 
     if (altKey) {
-      axis = pskl.utils.FrameTransform.HORIZONTAL;
+      axis = ns.TransformUtils.HORIZONTAL;
     } else {
-      axis = pskl.utils.FrameTransform.VERTICAL;
+      axis = ns.TransformUtils.VERTICAL;
     }
 
-    pskl.utils.FrameTransform.flip(frame, axis);
+    ns.TransformUtils.flip(frame, axis);
   };
 
 })();

--- a/src/js/tools/transform/Rotate.js
+++ b/src/js/tools/transform/Rotate.js
@@ -10,18 +10,18 @@
       {key : 'shift', description : 'Apply to all frames'}];
   };
 
-  pskl.utils.inherit(ns.Rotate, ns.Transform);
+  pskl.utils.inherit(ns.Rotate, ns.AbstractTransformTool);
 
   ns.Rotate.prototype.applyToolOnFrame_ = function (frame, altKey) {
     var direction;
 
     if (altKey) {
-      direction = pskl.utils.FrameTransform.CLOCKWISE;
+      direction = ns.TransformUtils.CLOCKWISE;
     } else {
-      direction = pskl.utils.FrameTransform.COUNTERCLOCKWISE;
+      direction = ns.TransformUtils.COUNTERCLOCKWISE;
     }
 
-    pskl.utils.FrameTransform.rotate(frame, direction);
+    ns.TransformUtils.rotate(frame, direction);
   };
 
 })();

--- a/src/js/tools/transform/TransformUtils.js
+++ b/src/js/tools/transform/TransformUtils.js
@@ -1,8 +1,8 @@
 (function () {
-  var ns = $.namespace('pskl.utils');
+  var ns = $.namespace('pskl.tools.transform');
 
-  ns.FrameTransform = {
-    VERTICAL : 'vertical',
+  ns.TransformUtils = {
+    VERTICAL : 'VERTICAL',
     HORIZONTAL : 'HORIZONTAL',
     flip : function (frame, axis) {
       var clone = frame.clone();
@@ -10,9 +10,9 @@
       var h = frame.getHeight();
 
       clone.forEachPixel(function (color, x, y) {
-        if (axis === ns.FrameTransform.VERTICAL) {
+        if (axis === ns.TransformUtils.VERTICAL) {
           x = w - x - 1;
-        } else if (axis === ns.FrameTransform.HORIZONTAL) {
+        } else if (axis === ns.TransformUtils.HORIZONTAL) {
           y = h - y - 1;
         }
         frame.pixels[x][y] = color;
@@ -43,10 +43,10 @@
         // Perform the rotation
         var tmpX = x;
         var tmpY = y;
-        if (direction === ns.FrameTransform.CLOCKWISE) {
+        if (direction === ns.TransformUtils.CLOCKWISE) {
           x = tmpY;
           y = max - 1 - tmpX;
-        } else if (direction === ns.FrameTransform.COUNTERCLOCKWISE) {
+        } else if (direction === ns.TransformUtils.COUNTERCLOCKWISE) {
           y = tmpX;
           x = max - 1 - tmpY;
         }

--- a/src/piskel-script-list.js
+++ b/src/piskel-script-list.js
@@ -27,7 +27,6 @@
   "js/utils/Math.js",
   "js/utils/FileUtils.js",
   "js/utils/FileUtilsDesktop.js",
-  "js/utils/FrameTransform.js",
   "js/utils/FrameUtils.js",
   "js/utils/LayerUtils.js",
   "js/utils/ImageResizer.js",
@@ -185,10 +184,11 @@
   "js/tools/drawing/ColorPicker.js",
   "js/tools/drawing/ColorSwap.js",
   "js/tools/drawing/DitheringTool.js",
-  "js/tools/transform/Transform.js",
+  "js/tools/transform/AbstractTransformTool.js",
   "js/tools/transform/Clone.js",
   "js/tools/transform/Flip.js",
   "js/tools/transform/Rotate.js",
+  "js/tools/transform/TransformUtils.js",
 
   // Devtools
   "js/devtools/DrawingTestPlayer.js",

--- a/src/piskel-script-list.js
+++ b/src/piskel-script-list.js
@@ -162,6 +162,7 @@
   "js/service/CurrentColorsService.js",
   "js/service/FileDropperService.js",
   "js/service/SelectedColorsService.js",
+  "js/service/MouseStateService.js",
 
   // Tools
   "js/tools/ToolsHelper.js",

--- a/test/js/service/SelectedColorsServiceTest.js
+++ b/test/js/service/SelectedColorsServiceTest.js
@@ -3,10 +3,8 @@ describe("SelectedColorsService test suite", function() {
   it("returns the default selected colors initially", function() {
     var service = new pskl.service.SelectedColorsService();
     
-    var defaultSelectedColors = service.getColors();
-    expect(defaultSelectedColors.length).toBe(2);
-    expect(defaultSelectedColors[0]).toBe(Constants.DEFAULT_PEN_COLOR);
-    expect(defaultSelectedColors[1]).toBe(Constants.TRANSPARENT_COLOR);
+    expect(service.getPrimaryColor()).toBe(Constants.DEFAULT_PEN_COLOR);
+    expect(service.getSecondaryColor()).toBe(Constants.TRANSPARENT_COLOR);
   });
 
   it("reacts to PRIMARY_COLOR_SELECTED event", function() {
@@ -16,10 +14,8 @@ describe("SelectedColorsService test suite", function() {
     var expectedColor = "#123456";
     $.publish(Events.PRIMARY_COLOR_SELECTED, [expectedColor]);
 
-    var defaultSelectedColors = service.getColors();
-    expect(defaultSelectedColors.length).toBe(2);
-    expect(defaultSelectedColors[0]).toBe(expectedColor);
-    expect(defaultSelectedColors[1]).toBe(Constants.TRANSPARENT_COLOR);
+    expect(service.getPrimaryColor()).toBe(expectedColor);
+    expect(service.getSecondaryColor()).toBe(Constants.TRANSPARENT_COLOR);
   });
 
   it("reacts to SECONDARY_COLOR_SELECTED event", function() {
@@ -29,9 +25,7 @@ describe("SelectedColorsService test suite", function() {
     var expectedColor = "#123456";
     $.publish(Events.SECONDARY_COLOR_SELECTED, [expectedColor]);
 
-    var defaultSelectedColors = service.getColors();
-    expect(defaultSelectedColors.length).toBe(2);
-    expect(defaultSelectedColors[0]).toBe(Constants.DEFAULT_PEN_COLOR);
-    expect(defaultSelectedColors[1]).toBe(expectedColor);
+    expect(service.getPrimaryColor()).toBe(Constants.DEFAULT_PEN_COLOR);
+    expect(service.getSecondaryColor()).toBe(expectedColor);
   });
 });

--- a/test/js/tools/transform/TransformUtilsTest.js
+++ b/test/js/tools/transform/TransformUtilsTest.js
@@ -1,13 +1,13 @@
-describe("FrameTransform suite", function() {
+describe("TransformUtils suite", function() {
   var A = '#000000';
   var B = '#ff0000';
   var O = Constants.TRANSPARENT_COLOR;
 
-  var HORIZONTAL = pskl.utils.FrameTransform.HORIZONTAL;
-  var VERTICAL = pskl.utils.FrameTransform.VERTICAL;
+  var HORIZONTAL = pskl.tools.transform.TransformUtils.HORIZONTAL;
+  var VERTICAL = pskl.tools.transform.TransformUtils.VERTICAL;
 
-  var CLOCKWISE = pskl.utils.FrameTransform.CLOCKWISE;
-  var COUNTERCLOCKWISE = pskl.utils.FrameTransform.COUNTERCLOCKWISE;
+  var CLOCKWISE = pskl.tools.transform.TransformUtils.CLOCKWISE;
+  var COUNTERCLOCKWISE = pskl.tools.transform.TransformUtils.COUNTERCLOCKWISE;
 
   // shortcuts
   var frameEqualsGrid = test.testutils.frameEqualsGrid;
@@ -25,7 +25,7 @@ describe("FrameTransform suite", function() {
     ]));
 
     // should have flipped
-    pskl.utils.FrameTransform.flip(frame, VERTICAL);
+    pskl.tools.transform.TransformUtils.flip(frame, VERTICAL);
     frameEqualsGrid(frame, [
       [O, A],
       [B, O]
@@ -40,7 +40,7 @@ describe("FrameTransform suite", function() {
     ]));
 
     // should have flipped
-    pskl.utils.FrameTransform.flip(frame, HORIZONTAL);
+    pskl.tools.transform.TransformUtils.flip(frame, HORIZONTAL);
     frameEqualsGrid(frame, [
       [O, B],
       [A, O]
@@ -56,7 +56,7 @@ describe("FrameTransform suite", function() {
     ]));
 
     // should have flipped
-    pskl.utils.FrameTransform.flip(frame, VERTICAL);
+    pskl.tools.transform.TransformUtils.flip(frame, VERTICAL);
     frameEqualsGrid(frame, [
       [O, A],
       [O, A],
@@ -64,7 +64,7 @@ describe("FrameTransform suite", function() {
     ]);
 
     // should be the same
-    pskl.utils.FrameTransform.flip(frame, HORIZONTAL);
+    pskl.tools.transform.TransformUtils.flip(frame, HORIZONTAL);
     frameEqualsGrid(frame, [
       [O, A],
       [O, A],
@@ -84,28 +84,28 @@ describe("FrameTransform suite", function() {
     ]));
 
     // rotate once
-    pskl.utils.FrameTransform.rotate(frame, COUNTERCLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, COUNTERCLOCKWISE);
     frameEqualsGrid(frame, [
       [O, B],
       [A, O]
     ]);
 
     // rotate twice
-    pskl.utils.FrameTransform.rotate(frame, COUNTERCLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, COUNTERCLOCKWISE);
     frameEqualsGrid(frame, [
       [B, O],
       [O, A]
     ]);
 
     // rotate 3
-    pskl.utils.FrameTransform.rotate(frame, COUNTERCLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, COUNTERCLOCKWISE);
     frameEqualsGrid(frame, [
       [O, A],
       [B, O]
     ]);
 
     // rotate 4 - back to initial state
-    pskl.utils.FrameTransform.rotate(frame, COUNTERCLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, COUNTERCLOCKWISE);
     frameEqualsGrid(frame, [
       [A, O],
       [O, B]
@@ -120,28 +120,28 @@ describe("FrameTransform suite", function() {
     ]));
 
     // rotate once
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, A],
       [B, O]
     ]);
 
     // rotate twice
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [B, O],
       [O, A]
     ]);
 
     // rotate 3
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, B],
       [A, O]
     ]);
 
     // rotate 4 - back to initial state
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [A, O],
       [O, B]
@@ -158,7 +158,7 @@ describe("FrameTransform suite", function() {
     ]));
 
     // rotate once
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, O],
       [B, A],
@@ -167,7 +167,7 @@ describe("FrameTransform suite", function() {
     ]);
 
     // rotate twice
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, O],
       [O, B],
@@ -176,7 +176,7 @@ describe("FrameTransform suite", function() {
     ]);
 
     // rotate 3
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, O],
       [O, O],
@@ -185,7 +185,7 @@ describe("FrameTransform suite", function() {
     ]);
 
     // rotate 4
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, O],
       [A, O],
@@ -202,28 +202,28 @@ describe("FrameTransform suite", function() {
     ]));
 
     // rotate once
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, A, O, O],
       [O, B, O, O]
     ]);
 
     // rotate twice
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, B, A, O],
       [O, O, O, O]
     ]);
 
     // rotate 3
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, O, B, O],
       [O, O, A, O]
     ]);
 
     // rotate 4
-    pskl.utils.FrameTransform.rotate(frame, CLOCKWISE);
+    pskl.tools.transform.TransformUtils.rotate(frame, CLOCKWISE);
     frameEqualsGrid(frame, [
       [O, O, O, O],
       [O, A, B, O]


### PR DESCRIPTION
The goal of this list of changes is to remove the color arguments from all BaseTool/BaseSelect interfaces and rely on centralized/shared services to provide colors that tools should use.

The color that a tool should use is based on the current primary/secondary colors and if the right/left button of the mouse is used.
SelectedColorsService provides the primary/secondary colors.
The new service MouseStateService provides the mouse button state (and encapsulate properly the mousemove mouse button type bug in FF/IE).

Each tool can use these two services in the getToolColor base method to know which color to use, and the color argument can be removed from the applyToolAt/releaseToolAt/... methods.