### PR TITLE
Issue #348 : colorpicker showing on top of tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ cache
 *.sublime-project
 *.sublime-workspace
 
+# netbeans project folder
+nbproject
+
 # git stackdumps
 *.stackdump
 

--- a/src/css/spectrum/spectrum.css
+++ b/src/css/spectrum/spectrum.css
@@ -13,7 +13,7 @@ License: MIT
     *display: inline;
     *zoom: 1;
     /* https://github.com/bgrins/spectrum/issues/40 */
-    z-index: 20000;
+    z-index: 9999994;
     overflow: hidden;
 }
 .sp-container.sp-flat {

--- a/src/css/spectrum/spectrum.css
+++ b/src/css/spectrum/spectrum.css
@@ -13,7 +13,7 @@ License: MIT
     *display: inline;
     *zoom: 1;
     /* https://github.com/bgrins/spectrum/issues/40 */
-    z-index: 9999994;
+    z-index: 20000;
     overflow: hidden;
 }
 .sp-container.sp-flat {

--- a/src/css/tools.css
+++ b/src/css/tools.css
@@ -159,10 +159,3 @@
   );
 }
 
-.palette-value-displayer{
-    color: #FFF;
-    text-align: center;
-    clear: both;
-    padding-top: 3px;
-    min-height: 1em;
-}

--- a/src/css/tools.css
+++ b/src/css/tools.css
@@ -159,3 +159,10 @@
   );
 }
 
+.palette-value-displayer{
+    color: #FFF;
+    text-align: center;
+    clear: both;
+    padding-top: 3px;
+    min-height: 1em;
+}

--- a/src/js/controller/PaletteController.js
+++ b/src/js/controller/PaletteController.js
@@ -1,7 +1,9 @@
 (function () {
   var ns = $.namespace('pskl.controller');
 
-  ns.PaletteController = function () {};
+  ns.PaletteController = function () {
+      this.displayer = $('.palette-value-displayer');
+  };
 
   /**
    * @public
@@ -27,17 +29,19 @@
         tinycolor.setAlpha(1);
       }
     };
-
+    
     // Initialize colorpickers:
     var colorPicker = $('#color-picker');
     colorPicker.spectrum($.extend({color: Constants.DEFAULT_PEN_COLOR}, spectrumCfg));
     colorPicker.change({isPrimary : true}, $.proxy(this.onPickerChange_, this));
-    this.setTitleOnPicker_(Constants.DEFAULT_PEN_COLOR, colorPicker);
+    colorPicker.parent().mouseenter({isPrimary : true}, $.proxy(this.showValueDisplayer_, this))
+      .mouseleave($.proxy(this.hideValueDisplayer_, this));
 
     var secondaryColorPicker = $('#secondary-color-picker');
     secondaryColorPicker.spectrum($.extend({color: Constants.TRANSPARENT_COLOR}, spectrumCfg));
     secondaryColorPicker.change({isPrimary : false}, $.proxy(this.onPickerChange_, this));
-    this.setTitleOnPicker_(Constants.TRANSPARENT_COLOR, secondaryColorPicker);
+    secondaryColorPicker.parent().mouseenter({isPrimary : false}, $.proxy(this.showValueDisplayer_, this))
+      .mouseleave($.proxy(this.hideValueDisplayer_, this));
 
     var swapColorsIcon = $('.swap-colors-button');
     swapColorsIcon.click(this.swapColors.bind(this));
@@ -106,11 +110,19 @@
     } else {
       colorPicker.spectrum('set', color);
     }
-    this.setTitleOnPicker_(color, colorPicker);
   };
 
-  ns.PaletteController.prototype.setTitleOnPicker_ = function (title, colorPicker) {
-    var spectrumInputSelector = '.sp-replacer';
-    colorPicker.next(spectrumInputSelector).attr('title', title);
+  /**
+   * @private
+   */
+  ns.PaletteController.prototype.showValueDisplayer_ = function (evt) {
+    var color = evt.data.isPrimary ? pskl.app.selectedColorsService.getPrimaryColor() : pskl.app.selectedColorsService.getSecondaryColor();
+    this.displayer.html(color);
+  };
+  /**
+   * @private
+   */
+  ns.PaletteController.prototype.hideValueDisplayer_ = function (evt) {
+    this.displayer.html('');
   };
 })();

--- a/src/js/controller/PaletteController.js
+++ b/src/js/controller/PaletteController.js
@@ -2,7 +2,7 @@
   var ns = $.namespace('pskl.controller');
 
   ns.PaletteController = function () {
-      this.displayer = $('.palette-value-displayer');
+    this.displayer = $('.palette-value-displayer');
   };
 
   /**
@@ -29,7 +29,7 @@
         tinycolor.setAlpha(1);
       }
     };
-    
+
     // Initialize colorpickers:
     var colorPicker = $('#color-picker');
     colorPicker.spectrum($.extend({color: Constants.DEFAULT_PEN_COLOR}, spectrumCfg));
@@ -116,7 +116,9 @@
    * @private
    */
   ns.PaletteController.prototype.showValueDisplayer_ = function (evt) {
-    var color = evt.data.isPrimary ? pskl.app.selectedColorsService.getPrimaryColor() : pskl.app.selectedColorsService.getSecondaryColor();
+    var color = evt.data.isPrimary ?
+      pskl.app.selectedColorsService.getPrimaryColor() :
+      pskl.app.selectedColorsService.getSecondaryColor();
     this.displayer.html(color);
   };
   /**

--- a/src/js/controller/PaletteController.js
+++ b/src/js/controller/PaletteController.js
@@ -110,7 +110,8 @@
   };
 
   ns.PaletteController.prototype.setTitleOnPicker_ = function (title, colorPicker) {
-    var spectrumInputSelector = '.sp-replacer';
-    colorPicker.next(spectrumInputSelector).attr('title', title);
+    var parent = colorPicker.parent();
+    title = parent.data('initial-title') + '<br/>' + title;
+    parent.attr('data-original-title', title);
   };
 })();

--- a/src/js/controller/PaletteController.js
+++ b/src/js/controller/PaletteController.js
@@ -1,9 +1,7 @@
 (function () {
   var ns = $.namespace('pskl.controller');
 
-  ns.PaletteController = function () {
-    this.displayer = $('.palette-value-displayer');
-  };
+  ns.PaletteController = function () {};
 
   /**
    * @public
@@ -34,14 +32,12 @@
     var colorPicker = $('#color-picker');
     colorPicker.spectrum($.extend({color: Constants.DEFAULT_PEN_COLOR}, spectrumCfg));
     colorPicker.change({isPrimary : true}, $.proxy(this.onPickerChange_, this));
-    colorPicker.parent().mouseenter({isPrimary : true}, $.proxy(this.showValueDisplayer_, this))
-      .mouseleave($.proxy(this.hideValueDisplayer_, this));
+    this.setTitleOnPicker_(Constants.DEFAULT_PEN_COLOR, colorPicker);
 
     var secondaryColorPicker = $('#secondary-color-picker');
     secondaryColorPicker.spectrum($.extend({color: Constants.TRANSPARENT_COLOR}, spectrumCfg));
     secondaryColorPicker.change({isPrimary : false}, $.proxy(this.onPickerChange_, this));
-    secondaryColorPicker.parent().mouseenter({isPrimary : false}, $.proxy(this.showValueDisplayer_, this))
-      .mouseleave($.proxy(this.hideValueDisplayer_, this));
+    this.setTitleOnPicker_(Constants.TRANSPARENT_COLOR, secondaryColorPicker);
 
     var swapColorsIcon = $('.swap-colors-button');
     swapColorsIcon.click(this.swapColors.bind(this));
@@ -110,21 +106,11 @@
     } else {
       colorPicker.spectrum('set', color);
     }
+    this.setTitleOnPicker_(color, colorPicker);
   };
 
-  /**
-   * @private
-   */
-  ns.PaletteController.prototype.showValueDisplayer_ = function (evt) {
-    var color = evt.data.isPrimary ?
-      pskl.app.selectedColorsService.getPrimaryColor() :
-      pskl.app.selectedColorsService.getSecondaryColor();
-    this.displayer.html(color);
-  };
-  /**
-   * @private
-   */
-  ns.PaletteController.prototype.hideValueDisplayer_ = function (evt) {
-    this.displayer.html('');
+  ns.PaletteController.prototype.setTitleOnPicker_ = function (title, colorPicker) {
+    var spectrumInputSelector = '.sp-replacer';
+    colorPicker.next(spectrumInputSelector).attr('title', title);
   };
 })();

--- a/src/templates/drawing-tools.html
+++ b/src/templates/drawing-tools.html
@@ -13,7 +13,7 @@
       <div class="palette-wrapper">
         <div
           class="tool-icon tool-color-picker"
-          title="Primary - left mouse button"
+          data-initial-title="Primary - left mouse button"
           rel="tooltip"
           data-placement="right"
         >
@@ -21,7 +21,7 @@
         </div>
         <div
           class="tool-icon tool-color-picker"
-          title="Secondary - right mouse button"
+          data-initial-title="Secondary - right mouse button"
           rel="tooltip"
           data-placement="right"
         >

--- a/src/templates/drawing-tools.html
+++ b/src/templates/drawing-tools.html
@@ -33,6 +33,7 @@
           rel="tooltip"
           data-placement="right"
         ></div>
+        <div class="palette-value-displayer"></div>
       </div>
     </div>
   </div>

--- a/src/templates/drawing-tools.html
+++ b/src/templates/drawing-tools.html
@@ -33,7 +33,6 @@
           rel="tooltip"
           data-placement="right"
         ></div>
-        <div class="palette-value-displayer"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
fix #348
Reorder z-indexes to display palette tooltip hover spectrum popover.
Remove title attribute on color selector and add a proposition as a replacement.