### PR TITLE
Issue #411: Export as ZIP: Pad frame numbers with leading zeroes

### DIFF
--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -64,20 +64,27 @@
       var frame = this.piskelController.getFrameAt(i);
       var canvas = this.getFrameAsCanvas_(frame);
       var basename = this.pngFilePrefixInput.value;
-      var filename = basename + (padding + (i + 1)).slice(-paddingLength) + '.png';
+      var id = (padding + (i + 1)).slice(-paddingLength);
+      var filename = basename + id + '.png';
       zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
     }
   };
 
   ns.PngExportController.prototype.splittedExport_ = function (zip) {
+    var framePaddingLength = (""+this.piskelController.getFrameCount()).length;
+    var framePadding = new Array(framePaddingLength).join("0");
     var layers = this.piskelController.getLayers();
+    var layerPaddingLength = (""+layers.length).length;
+    var layerPadding = new Array(layerPaddingLength).join("0");
     for (var j = 0; this.piskelController.hasLayerAt(j); j++) {
       var layer = this.piskelController.getLayerAt(j);
+      var layerid = (layerPadding + j).slice(-layerPaddingLength);
       for (var i = 0; i < this.piskelController.getFrameCount(); i++) {
         var frame = layer.getFrameAt(i);
         var canvas = this.getFrameAsCanvas_(frame);
         var basename = this.pngFilePrefixInput.value;
-        var filename = 'l' + j + '_' + basename + (i + 1) + '.png';
+        var frameid = (framePadding + (i + 1)).slice(-framePaddingLength);
+        var filename = 'l' + layerid + '_' + basename + frameid + '.png';
         zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
       }
     }

--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -59,31 +59,28 @@
 
   ns.PngExportController.prototype.mergedExport_ = function (zip) {
     var paddingLength = (""+this.piskelController.getFrameCount()).length;
-    var padding = new Array(paddingLength).join("0");
     for (var i = 0; i < this.piskelController.getFrameCount(); i++) {
       var frame = this.piskelController.getFrameAt(i);
       var canvas = this.getFrameAsCanvas_(frame);
       var basename = this.pngFilePrefixInput.value;
-      var id = (padding + (i + 1)).slice(-paddingLength);
+      var id = pskl.utils.StringUtils.leftPad(i, paddingLength, "0");
       var filename = basename + id + '.png';
       zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
     }
   };
 
   ns.PngExportController.prototype.splittedExport_ = function (zip) {
-    var framePaddingLength = (""+this.piskelController.getFrameCount()).length;
-    var framePadding = new Array(framePaddingLength).join("0");
     var layers = this.piskelController.getLayers();
+    var framePaddingLength = (""+this.piskelController.getFrameCount()).length;
     var layerPaddingLength = (""+layers.length).length;
-    var layerPadding = new Array(layerPaddingLength).join("0");
     for (var j = 0; this.piskelController.hasLayerAt(j); j++) {
       var layer = this.piskelController.getLayerAt(j);
-      var layerid = (layerPadding + j).slice(-layerPaddingLength);
+      var layerid = pskl.utils.StringUtils.leftPad(j, layerPaddingLength, "0");
       for (var i = 0; i < this.piskelController.getFrameCount(); i++) {
         var frame = layer.getFrameAt(i);
         var canvas = this.getFrameAsCanvas_(frame);
         var basename = this.pngFilePrefixInput.value;
-        var frameid = (framePadding + (i + 1)).slice(-framePaddingLength);
+        var frameid = pskl.utils.StringUtils.leftPad(i + 1, framePaddingLength, "0");
         var filename = 'l' + layerid + '_' + basename + frameid + '.png';
         zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
       }

--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -58,11 +58,13 @@
   };
 
   ns.PngExportController.prototype.mergedExport_ = function (zip) {
+    var paddingLength = (""+this.piskelController.getFrameCount()).length;
+    var padding = new Array(paddingLength).join("0");
     for (var i = 0; i < this.piskelController.getFrameCount(); i++) {
       var frame = this.piskelController.getFrameAt(i);
       var canvas = this.getFrameAsCanvas_(frame);
       var basename = this.pngFilePrefixInput.value;
-      var filename = basename + (i + 1) + '.png';
+      var filename = basename + (padding + (i + 1)).slice(-paddingLength) + '.png';
       zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
     }
   };

--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -58,12 +58,12 @@
   };
 
   ns.PngExportController.prototype.mergedExport_ = function (zip) {
-    var paddingLength = (""+this.piskelController.getFrameCount()).length;
+    var paddingLength = ('' + this.piskelController.getFrameCount()).length;
     for (var i = 0; i < this.piskelController.getFrameCount(); i++) {
       var frame = this.piskelController.getFrameAt(i);
       var canvas = this.getFrameAsCanvas_(frame);
       var basename = this.pngFilePrefixInput.value;
-      var id = pskl.utils.StringUtils.leftPad(i, paddingLength, "0");
+      var id = pskl.utils.StringUtils.leftPad(i, paddingLength, '0');
       var filename = basename + id + '.png';
       zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
     }
@@ -71,16 +71,16 @@
 
   ns.PngExportController.prototype.splittedExport_ = function (zip) {
     var layers = this.piskelController.getLayers();
-    var framePaddingLength = (""+this.piskelController.getFrameCount()).length;
-    var layerPaddingLength = (""+layers.length).length;
+    var framePaddingLength = ('' + this.piskelController.getFrameCount()).length;
+    var layerPaddingLength = ('' + layers.length).length;
     for (var j = 0; this.piskelController.hasLayerAt(j); j++) {
       var layer = this.piskelController.getLayerAt(j);
-      var layerid = pskl.utils.StringUtils.leftPad(j, layerPaddingLength, "0");
+      var layerid = pskl.utils.StringUtils.leftPad(j, layerPaddingLength, '0');
       for (var i = 0; i < this.piskelController.getFrameCount(); i++) {
         var frame = layer.getFrameAt(i);
         var canvas = this.getFrameAsCanvas_(frame);
         var basename = this.pngFilePrefixInput.value;
-        var frameid = pskl.utils.StringUtils.leftPad(i + 1, framePaddingLength, "0");
+        var frameid = pskl.utils.StringUtils.leftPad(i + 1, framePaddingLength, '0');
         var filename = 'l' + layerid + '_' + basename + frameid + '.png';
         zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
       }

--- a/src/js/utils/StringUtils.js
+++ b/src/js/utils/StringUtils.js
@@ -6,5 +6,5 @@
       var padding = new Array(length).join(pad);
       return (padding + input).slice(-length);
     },
-  }
+  };
 })();

--- a/src/js/utils/StringUtils.js
+++ b/src/js/utils/StringUtils.js
@@ -1,0 +1,10 @@
+(function () {
+  var ns = $.namespace('pskl.utils');
+
+  ns.StringUtils = {
+    leftPad : function (input, length, pad) {
+      var padding = new Array(length).join(pad);
+      return (padding + input).slice(-length);
+    },
+  }
+})();

--- a/src/piskel-script-list.js
+++ b/src/piskel-script-list.js
@@ -32,6 +32,7 @@
   "js/utils/LayerUtils.js",
   "js/utils/PixelUtils.js",
   "js/utils/PiskelFileUtils.js",
+  "js/utils/StringUtils.js",
   "js/utils/Template.js",
   "js/utils/TooltipFormatter.js",
   "js/utils/UserSettings.js",


### PR DESCRIPTION
I wrote up the code to address issue #411.

As suggested in the issue comments I added the padding function to a new StringUtils.js utility.

I don't know how you'd merge the mergedExport and splittedExport to remove the duplicate code (they're just a little bit too different) but I'm open to suggestions.