### PR TITLE
Downgrade grunt to ^0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "dateformat": "1.0.11",
-    "grunt": "1.0.1",
+    "grunt": "^0.4.5",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-concat": "1.0.1",
     "grunt-contrib-connect": "1.0.2",


### PR DESCRIPTION
This eliminates the peerDependencies complaints on `npm install` from the various grunt plugins being used.  I looked at upgrading the plugins but several still have no official support for grunt 1+.

This [shows up in your Travis builds](https://travis-ci.org/juliandescottes/piskel/builds/133800399) but is apparently nonfatal:

![screenshot from 2016-06-03 13-40-59](https://cloud.githubusercontent.com/assets/1615761/15792269/0ce03b08-2991-11e6-9f1d-336ef46b23ef.png)

On my own machine, this results in the following error on a clean `npm install`. Not sure in what capacity this is due to my older version of node/npm:

```
npm ERR! Linux 4.4.0-22-generic
npm ERR! argv "/home/brad/.nvm/versions/node/v0.12.7/bin/node" "/home/brad/.nvm/versions/node/v0.12.7/bin/npm" "install"
npm ERR! node v0.12.7
npm ERR! npm  v2.11.3
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package grunt does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-ghost@1.1.0 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-include-replace@4.0.1 wants grunt@~0.4.4 || ^1.0.1
npm ERR! peerinvalid Peer grunt-karma@1.0.0 wants grunt@>=0.4.x
npm ERR! peerinvalid Peer grunt-contrib-concat@1.0.1 wants grunt@>=0.4.0
npm ERR! peerinvalid Peer grunt-contrib-connect@1.0.2 wants grunt@>=0.4.0
npm ERR! peerinvalid Peer load-grunt-tasks@3.5.0 wants grunt@>=0.4.0
npm ERR! peerinvalid Peer grunt-contrib-clean@1.0.0 wants grunt@>= 0.4.5
npm ERR! peerinvalid Peer grunt-contrib-jshint@1.0.0 wants grunt@>=0.4.0
npm ERR! peerinvalid Peer grunt-nw-builder@2.0.0 wants grunt@~0.4.2
```

I've already [made this change in our fork](https://github.com/code-dot-org/piskel/pull/2) since most of our devs are on this older node version.  Just thought I'd suggest it upstream too.  It [looks like the original 0.4.5 > 1.0.1 update was a greenkeeper suggestion](https://github.com/juliandescottes/piskel/commit/77fb50701f3a1ed418536c9dfe9e4650a4cc17e2), but unlikely that it's actually needed for your repo.