### PR TITLE
Extract import logic to ImportService

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -124,6 +124,8 @@
       this.storageService = new pskl.service.storage.StorageService(this.piskelController);
       this.storageService.init();
 
+      this.importService = new pskl.service.ImportService(this.piskelController, this.previewController);
+
       this.imageUploadService = new pskl.service.ImageUploadService();
       this.imageUploadService.init();
 

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -1,8 +1,8 @@
-/* Image and Animation import service supporting the import dialogs,
- * file dropper service, and headless import API. */
+/* @file Image and Animation import service supporting the import dialog. */
 (function () {
   var ns = $.namespace('pskl.service');
   /**
+   * Image an animation import service supporting the import dialog.
    * @param {!PiskelController} piskelController
    * @param {!PreviewController} previewController
    * @constructor
@@ -14,6 +14,8 @@
   };
 
   /**
+   * Given an image object and some options, create a new Piskel and open it
+   * for editing.
    * @param {!Image} image
    * @param {!Object} options
    * @param {!string} options.importType - 'single' if not spritesheet

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -27,7 +27,7 @@
    * @param {function} [onComplete]
    */
   ns.ImportService.prototype.newPiskelFromImage = function (image, options, onComplete) {
-    onComplete = onComplete || function () {};
+    onComplete = onComplete || Constants.EMPTY_FUNCTION;
     var importType = options.importType;
     var frameSizeX = options.frameSizeX;
     var frameSizeY = options.frameSizeY;

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -1,12 +1,13 @@
 /* Image and Animation import service supporting the import dialogs,
  * file dropper service, and headless import API. */
 (function () {
+  var ns = $.namespace('pskl.service');
   /**
    * @param {!PiskelController} piskelController
    * @param {!PreviewController} previewController
    * @constructor
    */
-  var ImportService = $.namespace('pskl.service').ImportService =
+  ns.ImportService =
       function (piskelController, previewController) {
     this.piskelController_ = piskelController;
     this.previewController_ = previewController;
@@ -23,7 +24,7 @@
    * @param {!boolean} options.smoothing
    * @param {function} [onComplete]
    */
-  ImportService.prototype.newPiskelFromImage = function (image, options, onComplete) {
+  ns.ImportService.prototype.newPiskelFromImage = function (image, options, onComplete) {
     onComplete = onComplete || function () {};
     var importType = options.importType;
     var frameSizeX = options.frameSizeX;
@@ -74,7 +75,7 @@
    * @returns {canvas[]}
    * @private
    */
-  ImportService.prototype.createImagesFromSheet_ = function (image,
+  ns.ImportService.prototype.createImagesFromSheet_ = function (image,
       frameSizeX, frameSizeY, frameOffsetX, frameOffsetY) {
     return pskl.utils.CanvasUtils.createFramesFromImage(
         image,
@@ -93,7 +94,7 @@
    * @param {!boolean} smoothing
    * @private
    */
-  ImportService.prototype.createPiskelFromImages_ = function (images,
+  ns.ImportService.prototype.createPiskelFromImages_ = function (images,
       frameSizeX, frameSizeY, smoothing) {
     var frames = this.createFramesFromImages_(images, frameSizeX, frameSizeY, smoothing);
     var layer = pskl.model.Layer.fromFrames('Layer 1', frames);
@@ -112,7 +113,7 @@
    * @returns {pskl.model.Frame[]}
    * @private
    */
-  ImportService.prototype.createFramesFromImages_ = function (images, frameSizeX, frameSizeY, smoothing) {
+  ns.ImportService.prototype.createFramesFromImages_ = function (images, frameSizeX, frameSizeY, smoothing) {
     return images.map(function (image) {
       var resizedImage = pskl.utils.ImageResizer.resize(image, frameSizeX, frameSizeY, smoothing);
       return pskl.utils.FrameUtils.createFromImage(resizedImage);

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -1,0 +1,121 @@
+/* Image and Animation import service supporting the import dialogs,
+ * file dropper service, and headless import API. */
+(function () {
+  /**
+   * @param {!PiskelController} piskelController
+   * @param {!PreviewController} previewController
+   * @constructor
+   */
+  var ImportService = $.namespace('pskl.service').ImportService =
+      function (piskelController, previewController) {
+    this.piskelController_ = piskelController;
+    this.previewController_ = previewController;
+  };
+
+  /**
+   * @param {!Image} image
+   * @param {!Object} options
+   * @param {!string} options.importType - 'single' if not spritesheet
+   * @param {!number} options.frameSizeX
+   * @param {!number} options.frameSizeY
+   * @param {number} [options.frameOffsetX] only used in spritesheet imports.
+   * @param {number} [options.frameOffsetY] only used in spritesheet imports.
+   * @param {!boolean} options.smoothing
+   * @param {function} [onComplete]
+   */
+  ImportService.prototype.newPiskelFromImage = function (image, options, onComplete) {
+    onComplete = onComplete || function () {};
+    var importType = options.importType;
+    var frameSizeX = options.frameSizeX;
+    var frameSizeY = options.frameSizeY;
+    var frameOffsetX = options.frameOffsetX;
+    var frameOffsetY = options.frameOffsetY;
+
+    var gifLoader = new window.SuperGif({
+      gif: image
+    });
+
+    gifLoader.load({
+      success: function () {
+        var images = gifLoader.getFrames().map(function (frame) {
+          return pskl.utils.CanvasUtils.createFromImageData(frame.data);
+        });
+
+        if (importType === 'single' || images.length > 1) {
+          // Single image import or animated gif
+          this.createPiskelFromImages_(images, frameSizeX, frameSizeY, options.smoothing);
+        } else {
+          // Spritesheet
+          var frameImages = this.createImagesFromSheet_(images[0]);
+          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, options.smoothing);
+        }
+        onComplete();
+      }.bind(this),
+      error: function () {
+        if (importType === 'single') {
+          // Single image
+          this.createPiskelFromImages_([image], frameSizeX, frameSizeY, options.smoothing);
+        } else {
+          // Spritesheet
+          var frameImages = this.createImagesFromSheet_(image, frameSizeX, frameSizeY, frameOffsetX, frameOffsetY);
+          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, options.smoothing);
+        }
+        onComplete();
+      }.bind(this)
+    });
+  };
+
+  /**
+   * @param {!Image} image
+   * @param {!number} frameSizeX
+   * @param {!number} frameSizeY
+   * @param {!number} frameOffsetX
+   * @param {!number} frameOffsetY
+   * @returns {canvas[]}
+   * @private
+   */
+  ImportService.prototype.createImagesFromSheet_ = function (image,
+      frameSizeX, frameSizeY, frameOffsetX, frameOffsetY) {
+    return pskl.utils.CanvasUtils.createFramesFromImage(
+        image,
+        frameOffsetX,
+        frameOffsetY,
+        frameSizeX,
+        frameSizeY,
+        /*useHorizonalStrips=*/ true,
+        /*ignoreEmptyFrames=*/ true);
+  };
+
+  /**
+   * @param {canvas[]} images
+   * @param {!number} frameSizeX
+   * @param {!number} frameSizeY
+   * @param {!boolean} smoothing
+   * @private
+   */
+  ImportService.prototype.createPiskelFromImages_ = function (images,
+      frameSizeX, frameSizeY, smoothing) {
+    var frames = this.createFramesFromImages_(images, frameSizeX, frameSizeY, smoothing);
+    var layer = pskl.model.Layer.fromFrames('Layer 1', frames);
+    var descriptor = new pskl.model.piskel.Descriptor('Imported piskel', '');
+    var piskel = pskl.model.Piskel.fromLayers([layer], descriptor);
+
+    this.piskelController_.setPiskel(piskel);
+    this.previewController_.setFPS(Constants.DEFAULT.FPS);
+  };
+
+  /**
+   * @param {!canvas[]} images
+   * @param {!number} frameSizeX
+   * @param {!number} frameSizeY
+   * @param {!boolean} smoothing
+   * @returns {pskl.model.Frame[]}
+   * @private
+   */
+  ImportService.prototype.createFramesFromImages_ = function (images, frameSizeX, frameSizeY, smoothing) {
+    return images.map(function (image) {
+      var resizedImage = pskl.utils.ImageResizer.resize(image, frameSizeX, frameSizeY, smoothing);
+      return pskl.utils.FrameUtils.createFromImage(resizedImage);
+    });
+  };
+})();

--- a/src/piskel-script-list.js
+++ b/src/piskel-script-list.js
@@ -169,6 +169,7 @@
   "js/service/keyboard/Shortcut.js",
   "js/service/keyboard/Shortcuts.js",
   "js/service/keyboard/ShortcutService.js",
+  "js/service/ImportService.js",
   "js/service/ImageUploadService.js",
   "js/service/CurrentColorsService.js",
   "js/service/FileDropperService.js",


### PR DESCRIPTION
Isolates import dialog logic from actual import logic, which makes headless import easier to implement.

This is a small subset of the changes I just made in https://github.com/code-dot-org/piskel/pull/4 that I think usefully separate concerns for the upstream as well.  Right now it's only used by the import dialog, but I don't think we're far from a world where we want the `FileDropperService` to delegate to something like this too.