### PR TITLE
Prepare for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules/
+test/
+

--- a/misc/scripts/piskel-root
+++ b/misc/scripts/piskel-root
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// Writes the absolute path to the release build root to stdout
+var path = require('path');
+process.stdout.write(path.resolve(__dirname, '../../dest/prod') + '\n');

--- a/package.json
+++ b/package.json
@@ -6,16 +6,25 @@
   "contributors": [
     "Vincent Renaudin"
   ],
-  "main": "./dest/prod/index.html",
   "homepage": "http://github.com/juliandescottes/piskel",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "http://github.com/juliandescottes/piskel.git"
   },
+  "files": [
+    "dest/prod",
+    "misc/scripts/piskel-root"
+  ],
+  "bin": {
+    "piskel-root": "./misc/scripts/piskel-root"
+  },
+  "main": "./dest/prod/index.html",
   "scripts": {
     "test": "grunt test",
-    "start": "nodewebkit"
+    "start": "nodewebkit",
+    "preversion": "grunt test-local build",
+    "postversion": "git push && git push --tags && npm publish"
   },
   "devDependencies": {
     "dateformat": "1.0.11",


### PR DESCRIPTION
Introduces some small package changes that simplify publishing Piskel to NPM as a ready-to-use application (as suggested in https://github.com/juliandescottes/piskel/issues/477)

Since Piskel is not simply a JavaScript "module" (not something one would 'require' into another application) its role as a package on npm is somewhat unconventional - it contains the release build of Piskel, ready to serve as a static website, and a small `piskel-root` utility that will print the absolute path to that content (which will have been installed who-knows-where by npm).

Mostly this works by adding the "files" and "bin" entries to package.json, and by adding an .npmignore file (which simply prevents npm from using your .gitignore and ignoring the built files that we want to ship).

With these settings in place you could publish to npm anytime (as long as you have permission) but I've added `preversion` and `postversion` scripts to simplify and automate the process.  Here's how you publish a release:

```
npm login # If not already logged in
npm version [major|minor|patch|<other>] # see `npm help version` for more options
```

By itself this will lint, run the full test suite, do a release build, make sure the working directory is clean, bump the version number in package.json, commit the version number change and add a git tag with the new version, push the new version to GitHub and publish the release build output to npm.

Later if you want to automate more you could probably get this running within Travis CI.

If you don't have an npm account, create one at npmjs.com.  You'll need to do the initial release.

An npm user should then be able to download the latest Piskel release by running `npm install piskel`.  They could then find the location of Piskel's index.html by running `` `npm bin`/piskel-root `` (perhaps more useful for automation purposes... our own build copies the built Piskel release from its npm-installed location to a directory where it gets served by Rails).

By itself this may not seem _that_ useful, but it's a step toward making Piskel easier to embed with other appilications.  I've got a start on the next big improvement, where a parent application can `require('piskel')` to get an API object that facilitates communication with the editor running within an iframe.  You can see an early version of that at https://github.com/code-dot-org/piskel/pull/7