### PR TITLE
Replace 'alt' buttons with 'option' buttons on Macs?

### DIFF
--- a/src/js/controller/dialogs/CheatsheetController.js
+++ b/src/js/controller/dialogs/CheatsheetController.js
@@ -150,6 +150,7 @@
   ns.CheatsheetController.prototype.formatKey_ = function (key) {
     if (pskl.utils.UserAgent.isMac) {
       key = key.replace('ctrl', 'cmd');
+      key = key.replace('alt', 'option');
     }
     key = key.replace(/left/i, '&#65513;');
     key = key.replace(/up/i, '&#65514;');

--- a/src/js/utils/TooltipFormatter.js
+++ b/src/js/utils/TooltipFormatter.js
@@ -27,6 +27,7 @@
       descriptor.key = descriptor.key.toUpperCase();
       if (pskl.utils.UserAgent.isMac) {
         descriptor.key = descriptor.key.replace('CTRL', 'CMD');
+        descriptor.key = descriptor.key.replace('ALT', 'OPTION');
       }
     } else {
       tpl = pskl.utils.Template.get('tooltip-simple-descriptor-template');


### PR DESCRIPTION
Embarrassingly, I had a hard time finding the <kbd>ALT</kbd> button on my Macbook. 

![screen_shot_2016-07-20_at_6_12_00_pm](https://cloud.githubusercontent.com/assets/121322/17007403/a0ed36aa-4ea5-11e6-8615-897ebf64d13c.png)

It might be easier to refer to is as the <kbd>OPTION</kbd> button for users on Macs? The standard keyboard looks like this:

![image](https://cloud.githubusercontent.com/assets/121322/17007422/e656636a-4ea5-11e6-8abf-d66f9e3c896e.png)

This PR just replaces <kbd>ALT</kbd> button references with <kbd>OPTION</kbd> if the UserAgent looks like a Mac :metal: 


