### PR TITLE
Correct desktop window icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "window": {
     "title": "Piskel",
-    "icon": "dest/logo.png",
+    "icon": "dest/prod/logo.png",
     "toolbar": false,
     "width": 1000,
     "height": 500


### PR DESCRIPTION
I found the logo at dest/prod/logo.png, while there was no
dest/logo.png. Fixes juliandescottes/piskel#515