### PR TITLE
Add a flag to hide layer controls from the UI

### DIFF
--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -52,5 +52,8 @@ var Constants = {
   // SERVICE URLS
   APPENGINE_SAVE_URL : 'save',
   IMAGE_SERVICE_UPLOAD_URL : 'http://piskel-imgstore-b.appspot.com/__/upload',
-  IMAGE_SERVICE_GET_URL : 'http://piskel-imgstore-b.appspot.com/img/'
+  IMAGE_SERVICE_GET_URL : 'http://piskel-imgstore-b.appspot.com/img/',
+
+  // Hide or show layers controls from the UI
+  ENABLE_MULTIPLE_LAYERS: true
 };

--- a/src/js/controller/LayersListController.js
+++ b/src/js/controller/LayersListController.js
@@ -24,6 +24,15 @@
 
     $.subscribe(Events.PISKEL_RESET, this.renderLayerList_.bind(this));
     $.subscribe(Events.USER_SETTINGS_CHANGED, $.proxy(this.onUserSettingsChange_, this));
+
+    if (!Constants.ENABLE_MULTIPLE_LAYERS) {
+      this.rootEl.style.padding = '0px';
+      this.rootEl.style.visibility = 'hidden';
+      this.rootEl.style.height = '0px';
+      this.rootEl.style.width = '0px';
+      this.rootEl.style.margin = '0px';
+      this.rootEl.style.minHeight = '0px';
+    }
   };
 
   ns.LayersListController.prototype.renderLayerList_ = function () {

--- a/src/js/controller/TransformationsController.js
+++ b/src/js/controller/TransformationsController.js
@@ -17,6 +17,15 @@
     this.toolsContainer = container.querySelector('.tools-wrapper');
     container.addEventListener('click', this.onTransformationClick_.bind(this));
     this.createToolsDom_();
+
+    var cloneEl = document.querySelector('.icon-tool-clone');
+    if (!Constants.ENABLE_MULTIPLE_LAYERS) {
+      cloneEl.style.padding = '0px';
+      cloneEl.style.visibility = 'hidden';
+      cloneEl.style.height = '0px';
+      cloneEl.style.width = '0px';
+      cloneEl.style.margin = '0px';
+    }
   };
 
   ns.TransformationsController.prototype.applyTool = function (toolId, evt) {

--- a/src/js/tools/drawing/ColorSwap.js
+++ b/src/js/tools/drawing/ColorSwap.js
@@ -10,10 +10,11 @@
     this.helpText = 'Paint all pixels of the same color';
     this.shortcut = pskl.service.keyboard.Shortcuts.TOOL.COLORSWAP;
 
-    this.tooltipDescriptors = [
-      {key : 'ctrl', description : 'Apply to all layers'},
-      {key : 'shift', description : 'Apply to all frames'}
-    ];
+    this.tooltipDescriptors = [];
+    if (Constants.ENABLE_MULTIPLE_LAYERS) {
+      this.tooltipDescriptors.push({key : 'ctrl', description : 'Apply to all layers'});
+    }
+    this.tooltipDescriptors.push({key : 'shift', description : 'Apply to all frames'});
   };
 
   pskl.utils.inherit(ns.ColorSwap, ns.BaseTool);

--- a/src/js/tools/drawing/Move.js
+++ b/src/js/tools/drawing/Move.js
@@ -11,11 +11,12 @@
     this.helpText = 'Move tool';
     this.shortcut = pskl.service.keyboard.Shortcuts.TOOL.MOVE;
 
-    this.tooltipDescriptors = [
-      {key : 'ctrl', description : 'Apply to all layers'},
-      {key : 'shift', description : 'Apply to all frames'},
-      {key : 'alt', description : 'Wrap canvas borders'}
-    ];
+    this.tooltipDescriptors = [];
+    if (Constants.ENABLE_MULTIPLE_LAYERS) {
+      this.tooltipDescriptors.push({key : 'ctrl', description : 'Apply to all layers'});
+    }
+    this.tooltipDescriptors.push({key : 'shift', description : 'Apply to all frames'});
+    this.tooltipDescriptors.push({key : 'alt', description : 'Wrap canvas borders'});
 
     // Stroke's first point coordinates (set in applyToolAt)
     this.startCol = null;

--- a/src/js/tools/drawing/selection/BaseSelect.js
+++ b/src/js/tools/drawing/selection/BaseSelect.js
@@ -26,6 +26,9 @@
       {key : 'ctrl+v', description : 'Paste the copied area'},
       {key : 'shift', description : 'Hold to move the content'}
     ];
+    if (!Constants.ENABLE_MULTIPLE_LAYERS) {
+      this.tooltipDescriptors[0] = {description : 'Drag the selection to move it. You may switch to other frames.'};
+    }
   };
 
   pskl.utils.inherit(ns.BaseSelect, pskl.tools.drawing.BaseTool);

--- a/src/js/tools/transform/Center.js
+++ b/src/js/tools/transform/Center.js
@@ -4,10 +4,11 @@
   ns.Center = function () {
     this.toolId = 'tool-center';
     this.helpText = 'Align image to the center';
-    this.tooltipDescriptors = [
-      {key : 'ctrl', description : 'Apply to all layers'},
-      {key : 'shift', description : 'Apply to all frames'}
-    ];
+    this.tooltipDescriptors = [];
+    if (Constants.ENABLE_MULTIPLE_LAYERS) {
+      this.tooltipDescriptors.push({key : 'ctrl', description : 'Apply to all layers'});
+    }
+    this.tooltipDescriptors.push({key : 'shift', description : 'Apply to all frames'});
   };
 
   pskl.utils.inherit(ns.Center, ns.AbstractTransformTool);

--- a/src/js/tools/transform/Flip.js
+++ b/src/js/tools/transform/Flip.js
@@ -4,11 +4,12 @@
   ns.Flip = function () {
     this.toolId = 'tool-flip';
     this.helpText = 'Flip vertically';
-    this.tooltipDescriptors = [
-      {key : 'alt', description : 'Flip horizontally'},
-      {key : 'ctrl', description : 'Apply to all layers'},
-      {key : 'shift', description : 'Apply to all frames'}
-    ];
+
+    this.tooltipDescriptors = [{key : 'alt', description : 'Flip horizontally'}];
+    if (Constants.ENABLE_MULTIPLE_LAYERS) {
+      this.tooltipDescriptors.push({key : 'ctrl', description : 'Apply to all layers'});
+    }
+    this.tooltipDescriptors.push({key : 'shift', description : 'Apply to all frames'});
   };
 
   pskl.utils.inherit(ns.Flip, ns.AbstractTransformTool);

--- a/src/js/tools/transform/Rotate.js
+++ b/src/js/tools/transform/Rotate.js
@@ -4,10 +4,12 @@
   ns.Rotate = function () {
     this.toolId = 'tool-rotate';
     this.helpText = 'Counter-clockwise rotation';
-    this.tooltipDescriptors = [
-      {key : 'alt', description : 'Clockwise rotation'},
-      {key : 'ctrl', description : 'Apply to all layers'},
-      {key : 'shift', description : 'Apply to all frames'}];
+
+    this.tooltipDescriptors = [{key : 'alt', description : 'Clockwise rotation'}];
+    if (Constants.ENABLE_MULTIPLE_LAYERS) {
+      this.tooltipDescriptors.push({key : 'ctrl', description : 'Apply to all layers'});
+    }
+    this.tooltipDescriptors.push({key : 'shift', description : 'Apply to all frames'});
   };
 
   pskl.utils.inherit(ns.Rotate, ns.AbstractTransformTool);


### PR DESCRIPTION
Hi! As we are getting feedback on Gamelab (to be used in a middle school course for Code.org), we noticed that layers can be a challenging concept for younger students to grasp. We decided to remove it from the UI, but since this is more complicated than a simple css change, I made a flag that can be easily flipped on or off. With `ENABLE_MULTIPLE_LAYERS: true` there is no change to the current Piskel UI so I thought it could be useful in the original project. Thoughts?

Flag true (unchanged):
<img width="1045" alt="screen shot 2016-09-12 at 12 56 07 pm" src="https://cloud.githubusercontent.com/assets/4640747/18450588/85740486-78e8-11e6-8616-cfc65e507008.png">
Flag false:
<img width="1045" alt="screen shot 2016-09-12 at 12 56 35 pm" src="https://cloud.githubusercontent.com/assets/4640747/18450593/871238d0-78e8-11e6-9cb2-82f202a2ff71.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juliandescottes/piskel/545)
<!-- Reviewable:end -->
