### PR TITLE
Circle Retool for Large Pen Sizes

### DIFF
--- a/src/css/pensize.css
+++ b/src/css/pensize.css
@@ -47,3 +47,7 @@
 .pen-size-option.selected {
   border-color: gold;
 }
+
+.pen-size-option.labeled:before {
+  content: attr(real-pen-size);
+}

--- a/src/js/controller/PenSizeController.js
+++ b/src/js/controller/PenSizeController.js
@@ -25,9 +25,17 @@
   };
 
   ns.PenSizeController.prototype.updateSelectedOption_ = function () {
+    pskl.utils.Dom.removeClass('labeled', this.container);
     pskl.utils.Dom.removeClass('selected', this.container);
     var size = pskl.app.penSizeService.getPenSize();
-    var selectedOption = this.container.querySelector('[data-size="' + size + '"]');
+    var selectedOption;
+    if (size <= 4) {
+      selectedOption = this.container.querySelector('[data-size="' + size + '"]');
+    } else {
+      selectedOption = this.container.querySelector('[data-size="4"]');
+      selectedOption.classList.add('labeled');
+      selectedOption.setAttribute('real-pen-size', size);
+    }
     if (selectedOption) {
       selectedOption.classList.add('selected');
     }

--- a/src/js/service/pensize/PenSizeService.js
+++ b/src/js/service/pensize/PenSizeService.js
@@ -2,7 +2,7 @@
   var ns = $.namespace('pskl.service.pensize');
 
   var MIN_PENSIZE = 1;
-  var MAX_PENSIZE = 1000000;
+  var MAX_PENSIZE = 32;
 
   /**
    * Service to retrieve and modify the current pen size.

--- a/src/js/service/pensize/PenSizeService.js
+++ b/src/js/service/pensize/PenSizeService.js
@@ -2,7 +2,7 @@
   var ns = $.namespace('pskl.service.pensize');
 
   var MIN_PENSIZE = 1;
-  var MAX_PENSIZE = 4;
+  var MAX_PENSIZE = 1000000;
 
   /**
    * Service to retrieve and modify the current pen size.

--- a/src/js/tools/drawing/Circle.js
+++ b/src/js/tools/drawing/Circle.js
@@ -20,35 +20,45 @@
    * @override
    */
   ns.Circle.prototype.draw = function (col, row, color, targetFrame, penSize) {
-    var circlePixels = this.getCirclePixels_(this.startCol, this.startRow, col, row);
-    pskl.PixelUtils.resizePixels(circlePixels, penSize).forEach(function (point) {
+    this.getCirclePixels_(this.startCol, this.startRow, col, row, penSize).forEach(function (point) {
       targetFrame.setPixel(point[0], point[1], color);
     });
   };
 
-  ns.Circle.prototype.getCirclePixels_ = function (x0, y0, x1, y1) {
+  ns.Circle.prototype.getCirclePixels_ = function (x0, y0, x1, y1, penSize) {
     var coords = pskl.PixelUtils.getOrderedRectangleCoordinates(x0, y0, x1, y1);
-    var xC = (coords.x0 + coords.x1) / 2;
-    var yC = (coords.y0 + coords.y1) / 2;
+    var xC = Math.round((coords.x0 + coords.x1) / 2);
+    var yC = Math.round((coords.y0 + coords.y1) / 2);
 
     var rX = coords.x1 - xC;
     var rY = coords.y1 - yC;
+    var iX = rX - penSize;
+    var iY = rY - penSize;
+    if (iX < 0) {
+      iX = 0;
+    }
+    if (iY < 0) {
+      iY = 0;
+    }
 
     var pixels = [];
 
-    var x, y, angle;
-    for (x = coords.x0 ; x < coords.x1 ; x++) {
-      angle = Math.acos((x - xC) / rX);
-      y = Math.round(rY * Math.sin(angle) + yC);
-      pixels.push({'col': x, 'row': y});
-      pixels.push({'col': 2 * xC - x, 'row': 2 * yC - y});
-    }
-
-    for (y = coords.y0 ; y < coords.y1 ; y++) {
-      angle = Math.asin((y - yC) / rY);
-      x = Math.round(rX * Math.cos(angle) + xC);
-      pixels.push({'col': x, 'row': y});
-      pixels.push({'col': 2 * xC - x, 'row': 2 * yC - y});
+    var x, y, angle, r;
+    for (x = 0 ; x <= rX ; x++) {
+      for (y = 0 ; y <= rY ; y++) {
+        angle = Math.atan(y / x);
+        r = Math.sqrt(x * x + y * y);
+        if ((rX <= penSize || rY <= penSize ||
+          r > iX * iY / Math.sqrt(iY * iY * Math.pow(Math.cos(angle), 2) + iX * iX * Math.pow(Math.sin(angle), 2)) +
+          0.5) &&
+          r < rX * rY / Math.sqrt(rY * rY * Math.pow(Math.cos(angle), 2) + rX * rX * Math.pow(Math.sin(angle), 2)) +
+          0.5) {
+          pixels.push([xC + x, yC + y]);
+          pixels.push([xC - x, yC + y]);
+          pixels.push([xC + x, yC - y]);
+          pixels.push([xC - x, yC - y]);
+        }
+      }
     }
 
     return pixels;

--- a/src/js/tools/drawing/Circle.js
+++ b/src/js/tools/drawing/Circle.js
@@ -29,6 +29,8 @@
     var coords = pskl.PixelUtils.getOrderedRectangleCoordinates(x0, y0, x1, y1);
     var xC = Math.round((coords.x0 + coords.x1) / 2);
     var yC = Math.round((coords.y0 + coords.y1) / 2);
+    var evenX = (coords.x0 + coords.x1) % 2;
+    var evenY = (coords.y0 + coords.y1) % 2;
 
     var rX = coords.x1 - xC;
     var rY = coords.y1 - yC;
@@ -54,9 +56,9 @@
           r < rX * rY / Math.sqrt(rY * rY * Math.pow(Math.cos(angle), 2) + rX * rX * Math.pow(Math.sin(angle), 2)) +
           0.5) {
           pixels.push([xC + x, yC + y]);
-          pixels.push([xC - x, yC + y]);
-          pixels.push([xC + x, yC - y]);
-          pixels.push([xC - x, yC - y]);
+          pixels.push([xC - x - evenX, yC + y]);
+          pixels.push([xC + x, yC - y - evenY]);
+          pixels.push([xC - x - evenX, yC - y - evenY]);
         }
       }
     }

--- a/src/js/tools/drawing/Circle.js
+++ b/src/js/tools/drawing/Circle.js
@@ -26,14 +26,37 @@
   };
 
   ns.Circle.prototype.getCirclePixels_ = function (x0, y0, x1, y1, penSize) {
+
     var coords = pskl.PixelUtils.getOrderedRectangleCoordinates(x0, y0, x1, y1);
+    var pixels = [];
     var xC = Math.round((coords.x0 + coords.x1) / 2);
     var yC = Math.round((coords.y0 + coords.y1) / 2);
     var evenX = (coords.x0 + coords.x1) % 2;
     var evenY = (coords.y0 + coords.y1) % 2;
-
     var rX = coords.x1 - xC;
     var rY = coords.y1 - yC;
+    var x, y, angle, r;
+
+    if (penSize == 1) {
+      for (x = coords.x0 ; x <= xC ; x++) {
+        angle = Math.acos((x - xC) / rX);
+        y = Math.round(rY * Math.sin(angle) + yC);
+        pixels.push([x - evenX, y]);
+        pixels.push([x - evenX, 2 * yC - y - evenY]);
+        pixels.push([2 * xC - x, y]);
+        pixels.push([2 * xC - x, 2 * yC - y - evenY]);
+      }
+      for (y = coords.y0 ; y <= yC ; y++) {
+        angle = Math.asin((y - yC) / rY);
+        x = Math.round(rX * Math.cos(angle) + xC);
+        pixels.push([x, y - evenY]);
+        pixels.push([2 * xC - x - evenX, y - evenY]);
+        pixels.push([x, 2 * yC - y]);
+        pixels.push([2 * xC - x - evenX, 2 * yC - y]);
+      }
+      return pixels;
+    }
+
     var iX = rX - penSize;
     var iY = rY - penSize;
     if (iX < 0) {
@@ -43,9 +66,6 @@
       iY = 0;
     }
 
-    var pixels = [];
-
-    var x, y, angle, r;
     for (x = 0 ; x <= rX ; x++) {
       for (y = 0 ; y <= rY ; y++) {
         angle = Math.atan(y / x);

--- a/src/js/utils/PixelUtils.js
+++ b/src/js/utils/PixelUtils.js
@@ -76,33 +76,20 @@
      *
      * @param  {Number} row  x-coordinate of the original pixel
      * @param  {Number} col  y-coordinate of the original pixel
-     * @param  {Number} size >= 1 && <= 4
+     * @param  {Number} size >= 1 && <= 1000000
      * @return {Array}  array of arrays of 2 Numbers (eg. [[0,0], [0,1], [1,0], [1,1]])
      */
     resizePixel : function (col, row, size) {
-      if (size == 1) {
-        return [[col, row]];
-      } else if (size == 2) {
-        return [
-          [col, row], [col + 1, row],
-          [col, row + 1], [col + 1, row + 1]
-        ];
-      } else if (size == 3) {
-        return [
-          [col - 1, row - 1], [col, row - 1], [col + 1, row - 1],
-          [col - 1, row + 0], [col, row + 0], [col + 1, row + 0],
-          [col - 1, row + 1], [col, row + 1], [col + 1, row + 1],
-        ];
-      } else if (size == 4) {
-        return [
-          [col - 1, row - 1], [col, row - 1], [col + 1, row - 1], [col + 2, row - 1],
-          [col - 1, row + 0], [col, row + 0], [col + 1, row + 0], [col + 2, row + 0],
-          [col - 1, row + 1], [col, row + 1], [col + 1, row + 1], [col + 2, row + 1],
-          [col - 1, row + 2], [col, row + 2], [col + 1, row + 2], [col + 2, row + 2],
-        ];
-      } else {
-        console.error('Unsupported size : ' + size);
+      var pixels = [];
+      if(size > 1000000) size = 1000000;
+
+      for(j = 0; j < size; j++) {
+        for(i = 0; i < size; i++) {
+          pixels.push([col-Math.floor(size/2)+i,row-Math.floor(size/2)+j]);
+        }
       }
+
+      return pixels;
     },
 
     /**

--- a/src/js/utils/PixelUtils.js
+++ b/src/js/utils/PixelUtils.js
@@ -76,7 +76,7 @@
      *
      * @param  {Number} row  x-coordinate of the original pixel
      * @param  {Number} col  y-coordinate of the original pixel
-     * @param  {Number} size >= 1 && <= 1000000
+     * @param  {Number} size >= 1 && <= 32
      * @return {Array}  array of arrays of 2 Numbers (eg. [[0,0], [0,1], [1,0], [1,1]])
      */
     resizePixel : function (col, row, size) {
@@ -84,11 +84,9 @@
       var i;
       var j;
 
-      if (size > 1000000) { size = 1000000; }
-
       for (j = 0; j < size; j++) {
         for (i = 0; i < size; i++) {
-          pixels.push([col - Math.floor(size / 2) + i,row - Math.floor(size / 2) + j]);
+          pixels.push([col - Math.floor(size / 2) + i, row - Math.floor(size / 2) + j]);
         }
       }
 

--- a/src/js/utils/PixelUtils.js
+++ b/src/js/utils/PixelUtils.js
@@ -81,11 +81,14 @@
      */
     resizePixel : function (col, row, size) {
       var pixels = [];
-      if(size > 1000000) size = 1000000;
+      var i;
+      var j;
 
-      for(j = 0; j < size; j++) {
-        for(i = 0; i < size; i++) {
-          pixels.push([col-Math.floor(size/2)+i,row-Math.floor(size/2)+j]);
+      if (size > 1000000) { size = 1000000; }
+
+      for (j = 0; j < size; j++) {
+        for (i = 0; i < size; i++) {
+          pixels.push([col - Math.floor(size / 2) + i,row - Math.floor(size / 2) + j]);
         }
       }
 

--- a/src/templates/drawing-tools.html
+++ b/src/templates/drawing-tools.html
@@ -5,7 +5,7 @@
         <div class="pen-size-option" data-size="1"></div>
         <div class="pen-size-option" data-size="2"></div>
         <div class="pen-size-option" data-size="3"></div>
-        <div class="pen-size-option" data-size="4"></div>
+        <div class="pen-size-option" data-size="4" real-pen-size="6"></div>
       </div>
       <ul id="tools-container" class="tools-wrapper">
         <!-- Drawing tools will be inserted here -->

--- a/test/js/service/pensize/PenSizeServiceTest.js
+++ b/test/js/service/pensize/PenSizeServiceTest.js
@@ -56,7 +56,7 @@ describe("PenSize test suite", function() {
 
     penSizeService.init();
     // MAX_VALUE is 4
-    penSizeService.setPenSize(5);
+    penSizeService.setPenSize(33);
     expect(penSizeService.getPenSize()).toBe(1);
     // MIN_VALUE is 1
     penSizeService.setPenSize(0);


### PR DESCRIPTION
This vastly improves performance for the Circle/Ellipse tool when the pen size is particularly large. It isn't perfect yet -- the smaller ellipses behave a bit strange (~ 5 px), but it's a vast improvement from the lag pointed out on this thread: [https://github.com/juliandescottes/piskel/pull/560](url)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juliandescottes/piskel/572)
<!-- Reviewable:end -->
