### PR TITLE
Add a setting for changing the color format shown in the color picker

### DIFF
--- a/src/css/settings-application.css
+++ b/src/css/settings-application.css
@@ -54,7 +54,8 @@
   text-align: center;
 }
 
-.grid-width-select {
+.grid-width-select,
+.color-format-select {
   margin: 5px 5px 0 5px;
 }
 

--- a/src/js/controller/settings/ApplicationSettingsController.js
+++ b/src/js/controller/settings/ApplicationSettingsController.js
@@ -39,6 +39,16 @@
     maxFpsInput.value = pskl.UserSettings.get(pskl.UserSettings.MAX_FPS);
     this.addEventListener(maxFpsInput, 'change', this.onMaxFpsChange_);
 
+    // Color format
+    var colorFormat = pskl.UserSettings.get(pskl.UserSettings.COLOR_FORMAT);
+    var colorFormatSelect = document.querySelector('.color-format-select');
+    var selectedColorFormatOption = colorFormatSelect.querySelector('option[value="' + colorFormat + '"]');
+    if (selectedColorFormatOption) {
+      selectedColorFormatOption.setAttribute('selected', 'selected');
+    }
+
+    this.addEventListener(colorFormatSelect, 'change', this.onColorFormatChange_);
+
     // Layer preview opacity
     var layerOpacityInput = document.querySelector('.layer-opacity-input');
     layerOpacityInput.value = pskl.UserSettings.get(pskl.UserSettings.LAYER_OPACITY);
@@ -61,6 +71,10 @@
   ns.ApplicationSettingsController.prototype.onGridWidthChange_ = function (evt) {
     var width = parseInt(evt.target.value, 10);
     pskl.UserSettings.set(pskl.UserSettings.GRID_WIDTH, width);
+  };
+
+  ns.ApplicationSettingsController.prototype.onColorFormatChange_ = function (evt) {
+    pskl.UserSettings.set(pskl.UserSettings.COLOR_FORMAT, evt.target.value);
   };
 
   ns.ApplicationSettingsController.prototype.onSeamlessModeChange_ = function (evt) {

--- a/src/js/lib/spectrum/spectrum.js
+++ b/src/js/lib/spectrum/spectrum.js
@@ -671,7 +671,8 @@
 
             // Update the text entry input as it changes happen
             if (opts.showInput) {
-                textInput.val(realColor.toString(format));
+                var displayFormat = pskl.UserSettings.get(pskl.UserSettings.COLOR_FORMAT);
+                textInput.val(realColor.toString(displayFormat));
             }
 
             if (opts.showPalette) {

--- a/src/js/utils/UserSettings.js
+++ b/src/js/utils/UserSettings.js
@@ -17,6 +17,7 @@
     EXPORT_TAB: 'EXPORT_TAB',
     PEN_SIZE : 'PEN_SIZE',
     RESIZE_SETTINGS: 'RESIZE_SETTINGS',
+    COLOR_FORMAT: 'COLOR_FORMAT',
     KEY_TO_DEFAULT_VALUE_MAP_ : {
       'GRID_WIDTH' : 0,
       'MAX_FPS' : 24,
@@ -39,7 +40,8 @@
         maintainRatio : true,
         resizeContent : false,
         origin : 'TOPLEFT'
-      }
+      },
+      COLOR_FORMAT: 'hex',
     },
 
     /**

--- a/src/templates/settings/application.html
+++ b/src/templates/settings/application.html
@@ -58,6 +58,14 @@
         <input type="text" class="textfield  textfield-small  max-fps-input" autocomplete="off" name="max-fps"/>
       </div>
 
+      <div class="settings-item">
+        <label for="color-format">Color format</label>
+        <select id="color-format" class="color-format-select">
+          <option value="hex">Hex</option>
+          <option value="rgb">RGB</option>
+        </select>
+      </div>
+
       <input type="submit" class="button button-primary" value="Apply settings" />
     </div>
   </form>


### PR DESCRIPTION
This is a WIP pull request for the following issue: #563 

From what I can tell this covers the feature request as needed without breaking anything but I do want some input on it since this is my first attempt at contributing to this project.

Dropdown in the settings:
![settings](https://cloud.githubusercontent.com/assets/554766/21524120/09d2a80c-cd14-11e6-8d8a-3766bb2c8526.png)

The color picker with decimal color format:
![picker](https://cloud.githubusercontent.com/assets/554766/21524125/0cdbd352-cd14-11e6-90b5-d64802118abf.png)


I was initially listening for changes to the user settings in `PaletteController.js` as suggested in the issue. My guess was that the idea would be to update the pickers when the setting changes so that the UI stays up to date. It turned out to not be necessary for that reason, perhaps there was some other reason for listening to events there?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juliandescottes/piskel/599)
<!-- Reviewable:end -->
