### PR TITLE
Use standard HTML entities for the arrows displayed on the keyboard shortcut list

### DIFF
--- a/src/js/controller/dialogs/CheatsheetController.js
+++ b/src/js/controller/dialogs/CheatsheetController.js
@@ -152,10 +152,10 @@
       key = key.replace('ctrl', 'cmd');
       key = key.replace('alt', 'option');
     }
-    key = key.replace(/left/i, '&#65513;');
-    key = key.replace(/up/i, '&#65514;');
-    key = key.replace(/right/i, '&#65515;');
-    key = key.replace(/down/i, '&#65516;');
+    key = key.replace(/left/i, '&larr;');
+    key = key.replace(/up/i, '&uarr;');
+    key = key.replace(/right/i, '&rarr;');
+    key = key.replace(/down/i, '&darr;');
     key = key.replace(/>/g, '&gt;');
     key = key.replace(/</g, '&lt;');
     // add spaces around '+' delimiters


### PR DESCRIPTION
This is a fix for issue #628.

I don't have access to a Linux virtual machine at this point so it hasn't been tested. If someone has time to test it on Linux Firefox that would be great, otherwise I'll do it once I have access to a VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juliandescottes/piskel/634)
<!-- Reviewable:end -->
