### PR TITLE
Enable flipping for selected pixels

### DIFF
--- a/src/js/tools/transform/TransformUtils.js
+++ b/src/js/tools/transform/TransformUtils.js
@@ -6,14 +6,48 @@
     HORIZONTAL : 'HORIZONTAL',
     flip : function (frame, axis) {
       var clone = frame.clone();
-      var w = frame.getWidth();
-      var h = frame.getHeight();
+      var rightFlipBoundary;
+      var topFlipBoundary;
+      var selection = pskl.app.selectionManager.currentSelection;
+      var selectionIsRectangle = false;
+      var minx = +Infinity;
+      var miny = +Infinity;
+      var maxx = 0;
+      var maxy = 0;
+      if (selection) {
+        var px = selection.pixels;
+        if (px) {
+          for (var i = 0; i < px.length; ++i) {
+            var pixel = px[i];
+            minx = Math.min(minx, pixel.col);
+            miny = Math.min(miny, pixel.row);
+            maxx = Math.max(maxx, pixel.col);
+            maxy = Math.max(maxy, pixel.row);
+          }
+        }
+        var boundingRectArea = (maxx - minx + 1) * (maxy - miny + 1);
+        selectionIsRectangle = (boundingRectArea == px.length) && (px.length != 0);
+        topFlipBoundary = maxy;
+        rightFlipBoundary = maxx;
+      }
+      if (selectionIsRectangle) {
+        topFlipBoundary = miny + maxy + 1;
+        rightFlipBoundary = minx + maxx + 1;
+      } else {
+        topFlipBoundary = frame.getHeight();
+        rightFlipBoundary = frame.getWidth();
+      }
 
       clone.forEachPixel(function (color, x, y) {
+        if (selectionIsRectangle) {
+          if (((x < minx) || (x > maxx)) || ((y < miny) || (y > maxy))) {
+            return;
+          }
+        }
         if (axis === ns.TransformUtils.VERTICAL) {
-          x = w - x - 1;
+          x = rightFlipBoundary - x - 1;
         } else if (axis === ns.TransformUtils.HORIZONTAL) {
-          y = h - y - 1;
+          y = topFlipBoundary - y - 1;
         }
         frame.setPixel(x, y, color);
       });

--- a/test/js/tools/transform/TransformUtilsTest.js
+++ b/test/js/tools/transform/TransformUtilsTest.js
@@ -17,6 +17,16 @@ describe("TransformUtils suite", function() {
   /************ FLIP *************/
   /*******************************/
 
+
+  var selectionManager = new pskl.selection.SelectionManager();
+  selectionManager.init();
+
+  selection = new pskl.selection.BaseSelection();
+  selection.pixels = [];
+
+  selectionManager.currentSelection = selection;
+  pskl.app.selectionManager = selectionManager;
+
   it("flips a frame vertically", function () {
     // create frame
     var frame = pskl.model.Frame.fromPixelGrid(toFrameGrid([
@@ -24,6 +34,7 @@ describe("TransformUtils suite", function() {
       [O, B]
     ]));
 
+    selectionManager.currentSelection = selection;
     // should have flipped
     pskl.tools.transform.TransformUtils.flip(frame, VERTICAL);
     frameEqualsGrid(frame, [
@@ -55,6 +66,64 @@ describe("TransformUtils suite", function() {
       [A, O]
     ]));
 
+    // should have flipped
+    pskl.tools.transform.TransformUtils.flip(frame, VERTICAL);
+    frameEqualsGrid(frame, [
+      [O, A],
+      [O, A],
+      [O, A]
+    ]);
+
+    // should be the same
+    pskl.tools.transform.TransformUtils.flip(frame, HORIZONTAL);
+    frameEqualsGrid(frame, [
+      [O, A],
+      [O, A],
+      [O, A]
+    ]);
+  });
+
+
+  var createPixel = function(row, col, color) {
+    return {
+      row : row,
+      col : col,
+      color : color
+    };
+  };
+
+  it("flips selection", function () {
+    // create frame
+    var frame = pskl.model.Frame.fromPixelGrid(toFrameGrid([
+      [A, O, B],
+      [O, O, B],
+      [O, O, B]
+    ]));
+    // Select top left 2x2 square
+    selection.pixels.push(createPixel(0, 0));
+    selection.pixels.push(createPixel(1, 0));
+    selection.pixels.push(createPixel(0, 1));
+    selection.pixels.push(createPixel(1, 1));
+    // should be the same
+    pskl.tools.transform.TransformUtils.flip(frame, VERTICAL);
+    frameEqualsGrid(frame, [
+      [O, A, B],
+      [O, O, B],
+      [O, O, B]
+    ]);
+  })
+
+  it("flips normally for nonrectangular selection", function () {
+    // create frame
+    var frame = pskl.model.Frame.fromPixelGrid(toFrameGrid([
+      [A, O],
+      [A, O],
+      [A, O]
+    ]));
+
+    selection.pixels.push(createPixel(0, 0));
+    selection.pixels.push(createPixel(1, 0));
+    selection.pixels.push(createPixel(0, 1));
     // should have flipped
     pskl.tools.transform.TransformUtils.flip(frame, VERTICAL);
     frameEqualsGrid(frame, [


### PR DESCRIPTION
If the selected region is a rectangle, flip will only apply to that region instead of the entire frame.